### PR TITLE
Potential fix for code scanning alert no. 23: Disabling Electron webSecurity

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -188,8 +188,7 @@ app.on('ready', async () => {
         height: 720,
         webPreferences: {
             preload: path.join(__dirname, 'preload.js'),
-            contextIsolation: true,
-            webSecurity: false,
+            contextIsolation: true
         },
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/stjude/icore-image/security/code-scanning/23](https://github.com/stjude/icore-image/security/code-scanning/23)

To fix this problem, you should remove the `webSecurity: false` setting from the main window's `webPreferences` initialization. By default, `webSecurity` is enabled, so simply omitting this line will restore Electron’s default secure behavior. Only the configuration of the `BrowserWindow` constructor in the app's `ready` event (starting at line 186) should be changed—no additional imports or definitions are required. This change will not affect the application's ability to load local files (`loading.html` or resources from `preload.js`), nor will it impact the listed features. If you later need to temporarily relax web security for non-default reasons, consider alternatives that do not disable the same-origin checks, or only apply them on isolated or tightly controlled windows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
