### PR TITLE
Potential fix for code scanning alert no. 71: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: macos-15-intel
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/stjude/icore-image/security/code-scanning/71](https://github.com/stjude/icore-image/security/code-scanning/71)

To fix the problem, you should add an explicit `permissions` block to the workflow or job level in `.github/workflows/release.yml` so that the `GITHUB_TOKEN` only gets the needed permissions. For this workflow, the main write action is to create a release (via `softprops/action-gh-release@v1`), which requires `contents: write`. All other steps (such as code checkout, reading tags, or environment setup) can function with `contents: read` or no GitHub privileges at all.

The best, minimal fix is to add the following under the main job:
```yaml
permissions:
  contents: write
```
Alternatively, if you prefer, this can be done at the top of the workflow (to apply for all jobs), but since this workflow only has the one job (`release`), putting it under `release:` is sufficient and localizes the permission.

**What to change:**  
- Edit `.github/workflows/release.yml`.
- Add a `permissions:` block as the first key under the `release:` job (i.e., after line 9, before `runs-on:`).
- Set `contents: write` as the only permission.

No external dependencies or imports are needed for this YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
