### PR TITLE
Add typing, linting, and parallelize tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,3 +37,22 @@ jobs:
       - name: Run tests
         run: make test
 
+    type-check:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+        
+        - name: Setup uv
+          uses: astral-sh/setup-uv@v7
+          with:
+            version: '0.10.3'
+
+        - name: Set up Python
+          run: uv python install
+
+        - name: Install dependencies
+          run: uv sync
+
+        - name: Run ty
+          run: uv run ty check

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -7,6 +7,9 @@ on:
       - main
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   full-test:
     # Running on ubuntu because the docker tests are less flakey here

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,25 +37,25 @@ jobs:
       - name: Run tests
         run: make test
 
-    linting:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-        
-        - name: Setup uv
-          uses: astral-sh/setup-uv@v7
-          with:
-            version: '0.10.3'
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.10.3'
 
-        - name: Set up Python
-          run: uv python install
+      - name: Set up Python
+        run: uv python install
 
-        - name: Install dependencies
-          run: uv sync
+      - name: Install dependencies
+        run: uv sync
 
-        - name: Run ty
-          run: uv run ty check
+      - name: Run ty
+        run: uv run ty check
 
-        - name: Run ruff
-          run: uv run ruff check
+      - name: Run ruff
+        run: uv run ruff check

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: make test
 
-    type-check:
+    linting:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
@@ -56,3 +56,6 @@ jobs:
 
         - name: Run ty
           run: uv run ty check
+
+        - name: Run ruff
+          run: uv run ruff check

--- a/.nvimrc.example
+++ b/.nvimrc.example
@@ -1,0 +1,7 @@
+lua << EOF
+
+-- LSP configuration for Python
+vim.lsp.enable('ty')
+vim.lsp.enable('ruff-lsp')
+
+EOF

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 test:
 	@docker info > /dev/null 2>&1 || (echo "Error: Docker is not running. Please start Docker and try again." && exit 1)
-	uv run pytest -v --reruns 3 --reruns-delay 5
+	uv run pytest -v -n auto --reruns 3 --reruns-delay 5
 	cd electron && npm test -- --verbose
 
 dev: external-deps

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,56 @@
+"""
+Module-scoped Docker container fixtures for test performance.
+
+A single Orthanc/Azurite container is started per test module and shared across
+all tests in that module.  Data is cleared between tests so each test starts
+with a clean state.
+
+Using module scope (not session scope) so that pytest-xdist workers — which
+each run entire modules — get independent containers on independent random
+ports with no cross-worker conflicts.
+"""
+
+import pytest
+
+from test_utils import OrthancServer, AzuriteServer
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped containers (started once per test file, reused across tests)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def shared_orthanc():
+    """A single Orthanc container shared across all tests in a module."""
+    server = OrthancServer()
+    server.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def shared_azurite():
+    """A single Azurite container shared across all tests in a module."""
+    server = AzuriteServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped wrappers (clear data between tests)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def orthanc(shared_orthanc):
+    """Per-test Orthanc access.  Data is cleared after each test."""
+    yield shared_orthanc
+    shared_orthanc.clear_data()
+
+
+@pytest.fixture(scope="function")
+def azurite(shared_azurite):
+    """Per-test Azurite access.  Data is cleared after each test."""
+    yield shared_azurite
+    shared_azurite.clear_data()

--- a/ctp.py
+++ b/ctp.py
@@ -166,6 +166,8 @@ class CTPServer:
         root = tree.getroot()
         
         server_elem = root.find("Server")
+        if server_elem is None:
+            raise ValueError("config.xml missing <Server> element")
         self.port = int(server_elem.get("port", "50000"))
         
         quarantine_set = set()
@@ -969,6 +971,7 @@ class CTPPipeline:
         return response.text if response else None
     
     def _find_stage_index_by_id(self, stage_id):
+        assert self.server is not None
         config_path = os.path.join(self.server.ctp_dir, "config.xml")
         tree = ET.parse(config_path)
         root = tree.getroot()

--- a/ctp.py
+++ b/ctp.py
@@ -195,20 +195,30 @@ class CTPServer:
         
         env = {'JAVA_HOME': java_home}
         
+        self._stderr_file = tempfile.NamedTemporaryFile(delete=False, prefix="ctp_stderr_", suffix=".log")
+        self._stderr_path = self._stderr_file.name
+
         self.process = subprocess.Popen(
             cmd,
             cwd=self.ctp_dir,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=self._stderr_file,
             env=env
         )
-        
+
         self._running = True
-        
+
         time.sleep(3)
-        
+
         if self.process.poll() is not None:
-            raise RuntimeError("CTP process failed to start")
+            self._stderr_file.seek(0)
+            stderr_output = self._stderr_file.read()
+            self._stderr_file.close()
+            os.unlink(self._stderr_path)
+            raise RuntimeError(
+                f"CTP process failed to start (port {self.port})."
+                f"{' stderr: ' + stderr_output.decode('utf8').strip() if stderr_output.strip() else ''}"
+            )
         
         self._monitor_running = True
         self.monitor_thread = Thread(target=self._monitor_loop, daemon=True)
@@ -216,13 +226,18 @@ class CTPServer:
     
     def stop(self):
         self._monitor_running = False
-        
+
         if self.monitor_thread:
             self.monitor_thread.join(timeout=5)
-        
+
         if self.process:
             self._shutdown_process(self.process)
             self._running = False
+
+        if hasattr(self, '_stderr_file') and self._stderr_file and not self._stderr_file.closed:
+            self._stderr_file.close()
+        if hasattr(self, '_stderr_path') and os.path.exists(self._stderr_path):
+            os.unlink(self._stderr_path)
     
     def is_complete(self):
         if self._monitor_exception:
@@ -273,7 +288,7 @@ class CTPServer:
                 self._force_kill_by_port()
     
     def _force_kill_by_port(self):
-        for proc in psutil.process_iter(['pid', 'name', 'connections']):
+        for proc in psutil.process_iter(['pid', 'name']):
             try:
                 for conn in proc.net_connections():
                     if conn.laddr.port == self.port:
@@ -834,20 +849,14 @@ class CTPPipeline:
         return self.pipeline_type in ['imagedeid_pacs', 'imagedeid_pacs_pixel', 'imageqr']
     
     def _find_available_port(self, dicom_port_to_avoid=None):
-        start_port = 50000
-        max_attempts = 10
-        port_increment = 10
-        
-        for attempt in range(max_attempts):
-            port = start_port + (attempt * port_increment)
-            
-            if port == dicom_port_to_avoid:
-                continue
-            
-            if is_port_available(port):
+        # Use OS-assigned ephemeral port to avoid races between parallel workers
+        for _ in range(10):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(('localhost', 0))
+                port = s.getsockname()[1]
+            if port != dicom_port_to_avoid:
                 return port
-        
-        raise RuntimeError(f"Could not find available port after {max_attempts} attempts (tried ports {start_port} to {start_port + (max_attempts - 1) * port_increment})")
+        raise RuntimeError("Could not find available port that differs from DICOM port")
     
     def _force_kill_by_port(self, port):
         for proc in psutil.process_iter(['pid', 'name']):

--- a/dcmtk.py
+++ b/dcmtk.py
@@ -195,6 +195,7 @@ def find_studies(host, port, calling_aet, called_aet, query_params, query_level=
 
 
 def _return_last_result(retry_state: RetryCallState):
+    assert retry_state.outcome is not None
     return retry_state.outcome.result()
 
 def _log_get_retry(retry_state: RetryCallState):

--- a/dcmtk.py
+++ b/dcmtk.py
@@ -190,7 +190,7 @@ def find_studies(host, port, calling_aet, called_aet, query_params, query_level=
     finally:
         try:
             shutil.rmtree(temp_dir)
-        except:
+        except Exception:
             pass
 
 

--- a/dcmtk.py
+++ b/dcmtk.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 import xml.etree.ElementTree as ET
 
-from tenacity import retry, stop_after_attempt, wait_chain, wait_fixed, retry_if_exception_type, retry_if_result, RetryCallState, before_sleep_log
+from tenacity import retry, stop_after_attempt, wait_chain, wait_fixed, retry_if_exception_type, retry_if_result, RetryCallState
 
 
 class DCMTKError(Exception):

--- a/deid/grammar.py
+++ b/deid/grammar.py
@@ -62,7 +62,7 @@ def build_tag_dict():
     """
     if getattr(sys, 'frozen', False):
         # Running in a PyInstaller bundle
-        bundle_dir = sys._MEIPASS
+        bundle_dir = getattr(sys, '_MEIPASS')
         dict_path = Path(bundle_dir) / 'resources' / 'dictionary.xml'
         mapping_path = Path(bundle_dir) / 'resources' / 'pydicom_ctp_tag_dictionary.xml'
     else:
@@ -353,15 +353,15 @@ def generate_lookup_contents_legacy(lookup_file):
                 f"({', '.join(trigger_tags)}). CTP supports only one per tag."
             )
         trigger_tag = trigger_tags[0]
-        keytype = tag_keyword(output_tag)
+        keytype = tag_keyword(str(output_tag))
 
         for _, row in chunk.iterrows():
             trig_val = str(row["OriginalValue"]).strip()
             out_val = str(row["NewValue"]).strip()
             lookup_lines.append(f"{keytype}/{trig_val} = {out_val}")
         
-        trigger_name = trigger_tag.strip()
-        output_name = output_tag.strip()
+        trigger_name = str(trigger_tag).strip()
+        output_name = str(output_tag).strip()
         try:
             trigger_tag = tag_dict[trigger_name].replace('(', '').replace(',', '').replace(')', '')
         except KeyError:

--- a/deid/grammar.py
+++ b/deid/grammar.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pandas as pd
 import xml.etree.ElementTree as ET

--- a/deid/home/management/commands/worker.py
+++ b/deid/home/management/commands/worker.py
@@ -6,7 +6,6 @@ import sys
 import time
 import traceback
 from datetime import datetime
-from shutil import which
 
 import pandas as pd
 import pytz
@@ -15,8 +14,6 @@ from django.db import models, transaction
 from grammar import (
     generate_anonymizer_script,
     generate_filters_string,
-    generate_lookup_contents,
-    generate_lookup_table,
     generate_hipaa_safe_harbor_script,
     get_hipaa_safe_harbor_config,
 )
@@ -85,7 +82,7 @@ def run_subprocess_and_capture_log_path(cmd, env, task):
         
         return stdout_output
     
-    except Exception as e:
+    except Exception:
         process.kill()
         raise
 

--- a/deid/home/management/commands/worker.py
+++ b/deid/home/management/commands/worker.py
@@ -41,7 +41,6 @@ def run_subprocess_and_capture_log_path(cmd, env, task):
     task.process_pid = process.pid
     task.save()
     
-    log_path_captured = False
     stdout_lines = []
     stderr_lines = []
     
@@ -54,7 +53,7 @@ def run_subprocess_and_capture_log_path(cmd, env, task):
                 if 'log_path' in log_data:
                     task.log_path = log_data['log_path']
                     task.save()
-                    log_path_captured = True
+
                     print(f"Captured log path: {task.log_path}")
             except json.JSONDecodeError:
                 pass

--- a/deid/home/management/commands/worker.py
+++ b/deid/home/management/commands/worker.py
@@ -37,7 +37,10 @@ def run_subprocess_and_capture_log_path(cmd, env, task):
         text=True,
         bufsize=1
     )
-    
+
+    assert process.stdout is not None
+    assert process.stderr is not None
+
     task.process_pid = process.pid
     task.save()
     
@@ -148,12 +151,12 @@ def process_image_deid(task):
 
 def build_image_deid_config(task):
     """Build the configuration for image deidentification"""
-    config = {'module': 'imagedeid'}
-    
+    config: dict[str, object] = {'module': 'imagedeid'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
-    
+
     if task.image_source == 'PACS':
         config.update({
             'pacs': task.pacs_configs,
@@ -256,12 +259,12 @@ def process_image_query(task):
 
 def build_image_query_config(task):
     """Build the configuration for image query"""
-    config = {'module': 'imageqr'}
-    
+    config: dict[str, object] = {'module': 'imageqr'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
-    
+
     config.update({
             'pacs': task.pacs_configs,
             'application_aet': task.application_aet,
@@ -324,12 +327,12 @@ def process_header_query(task):
 
 def build_header_query_config(task):
     """Build the configuration for header query"""
-    config = {'module': 'headerqr'}
-    
+    config: dict[str, object] = {'module': 'headerqr'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
-    
+
     config.update({
             'pacs': task.pacs_configs,
             'application_aet': task.application_aet,
@@ -389,12 +392,12 @@ def process_header_extract(task):
 
 def build_header_extract_config(task):
     """Build the configuration for header extract"""
-    config = {'module': 'headerextract'}
-    
+    config: dict[str, object] = {'module': 'headerextract'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
-    
+
     extract_all_headers = task.parameters.get('extract_all_headers', False)
     config['extract_all_headers'] = extract_all_headers
     
@@ -442,8 +445,8 @@ def process_text_deid(task):
 
 def build_text_deid_config(task):
     """Build the configuration for text deidentification"""
-    config = {'module': 'textdeid'}
-    
+    config: dict[str, object] = {'module': 'textdeid'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
@@ -503,12 +506,12 @@ def build_image_export_config(task):
     """Build the configuration for image export"""
     settings = json.load(open(SETTINGS_PATH))
     
-    config = {
+    config: dict[str, object] = {
         'module': 'imageexport',
         'sas_url': task.parameters['sas_url'],
         'project_name': task.name,
     }
-    
+
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
     
@@ -601,8 +604,8 @@ def detect_file_type_and_columns(input_file_path):
 
 def build_singleclickicore_config(task):
     """Build the configuration for singleclickicore (image deid + text deid + export)"""
-    config = {'module': 'singleclickicore'}
-    
+    config: dict[str, object] = {'module': 'singleclickicore'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled
@@ -681,8 +684,8 @@ def build_singleclickicore_config(task):
 
 def build_image_deid_export_config(task):
     """Build the configuration for image deidentification and export"""
-    config = {'module': 'imagedeidexport'}
-    
+    config: dict[str, object] = {'module': 'imagedeidexport'}
+
     settings = json.load(open(SETTINGS_PATH))
     debug_enabled = settings.get('debug_logging', False)
     config['debug'] = debug_enabled

--- a/deid/home/views.py
+++ b/deid/home/views.py
@@ -146,7 +146,8 @@ class CommonContextMixin:
         }
     
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
+        # ty can't resolve get_context_data through Django's MRO (CommonContextMixin + CreateView)
+        context = super().get_context_data(**kwargs)  # ty: ignore[unresolved-attribute]
         context.update(self.get_common_context())
         return context
 
@@ -984,7 +985,8 @@ def test_pacs_connection(request):
     from pynetdicom import AE, sop_class
 
     ae = AE(ae_title=application_aet)
-    ae.add_requested_context(sop_class.Verification)
+    # pynetdicom dynamically generates sop_class.Verification; no type stub available
+    ae.add_requested_context(sop_class.Verification)  # ty: ignore[unresolved-attribute]
     pacs_port = int(pacs_port)
     try:
         assoc = ae.associate(pacs_ip, pacs_port, ae_title=pacs_aet)

--- a/deid/home/views.py
+++ b/deid/home/views.py
@@ -2,11 +2,8 @@ import logging
 import json
 import os
 import shutil
-import subprocess
 import sys
-import tempfile
 import time
-import socket
 from datetime import datetime, timezone as dt_timezone
 from urllib.parse import urlparse, parse_qs
 
@@ -65,7 +62,7 @@ def validate_sas_url_endpoint(request):
         if result.get('error') is not None:
             return JsonResponse({'valid': False, 'error': 'Validation error during SAS URL check'}, status=400)
         return JsonResponse({'valid': True, 'error': None}, status=200)
-    except Exception as e:
+    except Exception:
         return JsonResponse({'valid': False, 'error': 'Validation error during SAS URL check'}, status=500)
 
 

--- a/deid/home/views.py
+++ b/deid/home/views.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import time
 import socket
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from urllib.parse import urlparse, parse_qs
 
 import bcrypt
@@ -85,7 +85,7 @@ def _validate_sas_url(sas_url):
             expiry_str = query_params['se'][0]
             try:
                 expiry_time = datetime.strptime(expiry_str, '%Y-%m-%dT%H:%M:%SZ')
-                current_time = datetime.utcnow()
+                current_time = datetime.now(dt_timezone.utc)
                 
                 if current_time >= expiry_time:
                     return {"valid": False, "error": "SAS token has expired"}

--- a/deid/home/views.py
+++ b/deid/home/views.py
@@ -90,7 +90,7 @@ def _validate_sas_url(sas_url):
                 return {"valid": False, "error": "Invalid expiry date format in SAS token"}
         
         try:
-            account_name = parsed.netloc.split('.')[0]
+
             container_name = parsed.path.lstrip('/').split('/')[0]
             if not container_name:
                 return {"valid": False, "error": "Container name not found in URL"}

--- a/icore_processor.py
+++ b/icore_processor.py
@@ -254,6 +254,8 @@ def get_dcmtk_binary(binary_name):
         return binary_path
     else:
         dcmtk_home = os.environ.get('DCMTK_HOME')
+        if dcmtk_home is None:
+            raise ValueError("DCMTK_HOME environment variable must be set")
         return os.path.join(dcmtk_home, 'bin', binary_name)
 
 
@@ -263,6 +265,8 @@ def get_dcmtk_dict_path():
         return os.path.join(bundle_dir, '_internal', 'dcmtk', 'share', 'dcmtk-3.6.9', 'dicom.dic')
     else:
         dcmtk_home = os.environ.get('DCMTK_HOME')
+        if dcmtk_home is None:
+            raise ValueError("DCMTK_HOME environment variable must be set")
         return os.path.join(dcmtk_home, 'share', 'dcmtk-3.6.9', 'dicom.dic')
 
 
@@ -383,7 +387,10 @@ def ctp_post(url, data):
     return response.text
 
 def ctp_get_status(key):
-    return int(re.search(re.compile(rf"{key}:\s*<\/td><td>(\d+)"), ctp_get("status")).group(1))
+    match = re.search(re.compile(rf"{key}:\s*<\/td><td>(\d+)"), ctp_get("status"))
+    if match is None:
+        raise ValueError(f"Could not find status key: {key}")
+    return int(match.group(1))
 
 def count_files(path, exclude_files):
     return sum(len([f for f in files if not f.startswith('.') and f not in exclude_files]) for _, _, files in os.walk(path))
@@ -432,7 +439,9 @@ def start_ctp_run(tick_func, tick_data, logf, ctp_dir):
             java_home = os.path.join(bundle_dir, '_internal', 'jre8')
     else:
         java_home = os.environ.get('JAVA_HOME')
-    
+        if java_home is None:
+            raise ValueError("JAVA_HOME environment variable must be set")
+
     java_executable = os.path.join(java_home, "bin", "java")
     env = {'JAVA_HOME': java_home}
     
@@ -503,7 +512,7 @@ def ctp_workspace(func, data, config_setup_func=None):
 
 def setup_ctp_directory():
     if hasattr(sys, '_MEIPASS'):
-        source_ctp_dir = os.path.join(sys._MEIPASS, 'ctp')
+        source_ctp_dir = os.path.join(getattr(sys, '_MEIPASS'), 'ctp')
     else:
         source_ctp_dir = "ctp"
     
@@ -631,8 +640,8 @@ def cmove_queries(**config):
     else:
         mrn_dates = list(df[[config.get("mrn_col"), config.get("date_col")]].itertuples(index=False, name=None))
         for i, (mrn, dt) in enumerate(mrn_dates, 1):
-            dts = datetime.strftime((dt - timedelta(days=config.get("date_window"))), "%Y%m%d")
-            dte = datetime.strftime((dt + timedelta(days=config.get("date_window"))), "%Y%m%d")
+            dts = datetime.strftime((dt - timedelta(days=config.get("date_window", 0))), "%Y%m%d")
+            dte = datetime.strftime((dt + timedelta(days=config.get("date_window", 0))), "%Y%m%d")
             query = f"-k QueryRetrieveLevel=STUDY -k PatientID={str(mrn)} -k StudyDate={dts}-{dte}"
             queries.append(query)
             logging.info(f"Row {i}: MRN={mrn}, TargetDate={dt.strftime('%Y-%m-%d')}, Window={config.get('date_window')} days")
@@ -649,10 +658,10 @@ def cmove_images(logf, **config):
     
     queries, accession_numbers = cmove_queries(**config)
     
-    for pacs in config.get("pacs"):
+    for pacs in config.get("pacs", []):
         study_uids = set()
-        ip, port, aec = pacs.get("ip"), pacs.get("port"), pacs.get("ae")
-        aet, aem = config.get("application_aet"), config.get("application_aet")
+        ip, port, aec = pacs.get("ip", ""), pacs.get("port", ""), pacs.get("ae", "")
+        aet, aem = config.get("application_aet", ""), config.get("application_aet", "")
         logging.info(f"Querying PACS: {ip}:{port} (AE: {aec})")
         
         queries, accession_numbers = cmove_queries(**config)
@@ -1440,7 +1449,7 @@ def validate_config(config):
                 error_and_exit("pacs_ip, pacs_port, and pacs_aet have been deprecated. Please use the pacs list instead.")
             if not config.get("pacs"):
                 error_and_exit("Pacs details missing in config file.")
-            for pacs in config.get("pacs"):
+            for pacs in config.get("pacs", []):
                 if not all([pacs.get("ip"), pacs.get("port"), pacs.get("ae")]):
                     error_and_exit("Pacs details missing in config file.")
             if config.get("application_aet") is None or config.get("application_aet") == "":
@@ -1563,8 +1572,9 @@ def run_module(**config):
     logging.info("FULL CONFIG:")
     logging.info(yaml.dump(config, default_flow_style=False, sort_keys=False))
     logging.info("="*80)
-    if config.get("module") in ["imageqr", "imagedeid", "imageexport", "headerextract", "textdeid"]:
-        globals()[config.get("module")](**config)
+    module_name = config.get("module")
+    if module_name in ["imageqr", "imagedeid", "imageexport", "headerextract", "textdeid"]:
+        globals()[module_name](**config)
     else:
         generalmodule(**config)
 
@@ -1575,8 +1585,8 @@ if __name__ == "__main__":
     CONFIG_PATH = sys.argv[1]
     INPUT_DIR = sys.argv[2]
     OUTPUT_DIR = sys.argv[3]
-    APPDATA_DIR = os.environ.get('ICORE_APPDATA_DIR')
-    MODULES_DIR = os.environ.get('ICORE_MODULES_DIR')
+    APPDATA_DIR = os.environ.get('ICORE_APPDATA_DIR', "")
+    MODULES_DIR = os.environ.get('ICORE_MODULES_DIR', "")
 
     if not APPDATA_DIR:
         APPDATA_DIR = os.path.abspath(os.path.join(os.getcwd(), "appdata"))

--- a/icore_processor.py
+++ b/icore_processor.py
@@ -274,7 +274,6 @@ def create_analyzer_engine():
     if getattr(sys, 'frozen', False):
         bundle_dir = os.path.abspath(os.path.dirname(sys.executable))
         model_path = os.path.join(bundle_dir, '_internal', 'en_core_web_sm', 'en_core_web_sm-3.7.1')
-        import spacy
         from presidio_analyzer.nlp_engine import SpacyNlpEngine
         nlp_engine = SpacyNlpEngine(models=[{"lang_code": "en", "model_name": model_path}])
     else:
@@ -543,16 +542,16 @@ def save_config(config, ctp_dir):
 
 def parse_dicom_tag_dict(output):
     tags = {}
-    expr = rf".*\[(.+)\].+\#.+\,.+ (.+)"
+    expr = r".*\[(.+)\].+\#.+\,.+ (.+)"
     for value, tag in re.findall(expr, output):
         tags[tag.strip("\x00").strip()] = value.strip("\x00").strip()
-    expr = rf".*=(.+).+\#.+\,.+ (.+)"
+    expr = r".*=(.+).+\#.+\,.+ (.+)"
     for value, tag in re.findall(expr, output):
         tags[tag.strip("\x00").strip()] = value.strip("\x00").strip()
-    expr = rf".*FD (.+).+\#.+\,.+ (.+)"
+    expr = r".*FD (.+).+\#.+\,.+ (.+)"
     for value, tag in re.findall(expr, output):
         tags[tag.strip("\x00").strip()] = value.strip("\x00").strip()
-    expr = rf".*US (.+).+\#.+\,.+ (.+)"
+    expr = r".*US (.+).+\#.+\,.+ (.+)"
     for value, tag in re.findall(expr, output):
         tags[tag.strip("\x00").strip()] = value.strip("\x00").strip()
     return tags
@@ -694,7 +693,7 @@ def cmove_images(logf, **config):
                     logging.info(f"  Found StudyInstanceUID: {study_uid}, StudyDate: {study_date}")
             
             if studies_found_this_query == 0:
-                logging.info(f"  No studies found for this query")
+                logging.info("  No studies found for this query")
             else:
                 logging.info(f"  Total studies found for this query: {studies_found_this_query}")
             
@@ -1159,7 +1158,7 @@ def header_extract_main(**config):
         return
     
     try:
-        logging.info(f"Converting CSV to Excel format in batches...")
+        logging.info("Converting CSV to Excel format in batches...")
         
         chunk_size = 1000  # Process 1000 rows at a time
         all_chunks = []

--- a/icore_processor.py
+++ b/icore_processor.py
@@ -403,7 +403,7 @@ def count_dicom_files(path):
                     file.seek(128)
                     if file.read(4) == b'DICM':
                         dicom_count += 1
-            except:
+            except Exception:
                 continue
     return dicom_count
 
@@ -1359,18 +1359,6 @@ def textdeid_main(**config):
         print_and_log("PROGRESS: COMPLETE")
     except Exception as e:
         error_and_exit(f"Error: {e}")
-
-def validate_config(input_dir, output_dir, config):
-    if config is None:
-        error_and_exit("Config file unable to load or invalid.")
-    if not os.path.exists(input_dir):
-        error_and_exit("Input directory not found.")
-    if os.listdir(output_dir) != []:
-        error_and_exit("Output directory must be empty.")
-    if config.get("to_keep_list") is None or config.get("to_remove_list") is None:
-        error_and_exit("to_keep_list and to_remove_list must be provided.")
-    if config.get("date_shift_by") is None:
-        error_and_exit("Date shift by must be provided.")
 
 def validate_ctp_filters(filters):
     grammar = r"""start: expr

--- a/module_headerextract_local.py
+++ b/module_headerextract_local.py
@@ -24,7 +24,7 @@ def _extract_header_value(ds, header_name):
         if value is None:
             return ""
         return str(value)
-    except:
+    except Exception:
         return ""
 
 
@@ -115,7 +115,7 @@ def headerextract_local(input_dir, output_dir, headers_to_extract=None,
                             value = getattr(ds, attr_name, None)
                             if value is not None:
                                 header_data[attr_name] = str(value)
-                    except:
+                    except Exception:
                         pass
                 if header_data:
                     all_headers.append(header_data)

--- a/module_headerextract_local.py
+++ b/module_headerextract_local.py
@@ -4,11 +4,12 @@ import os
 
 import pandas as pd
 import pydicom
+from pydicom.dataset import Dataset
 
-from utils import configure_run_logging, format_number_with_commas, setup_run_directories
+from utils import HeaderExtractResult, RunDirs, configure_run_logging, format_number_with_commas, setup_run_directories
 
 
-def _find_dicom_files(input_dir):
+def _find_dicom_files(input_dir: str) -> list[str]:
     dicom_files = []
     for root, dirs, files in os.walk(input_dir):
         for file in files:
@@ -18,7 +19,7 @@ def _find_dicom_files(input_dir):
     return dicom_files
 
 
-def _extract_header_value(ds, header_name):
+def _extract_header_value(ds: Dataset, header_name: str) -> str:
     try:
         value = getattr(ds, header_name, "")
         if value is None:
@@ -28,32 +29,32 @@ def _extract_header_value(ds, header_name):
         return ""
 
 
-def _extract_headers_from_file(file_path, headers_to_extract):
+def _extract_headers_from_file(file_path: str, headers_to_extract: list[str]) -> dict[str, str] | None:
     try:
         ds = pydicom.dcmread(file_path, stop_before_pixels=True)
-        
+
         header_data = {}
         for header in headers_to_extract:
             header_data[header] = _extract_header_value(ds, header)
-        
+
         return header_data
     except Exception as e:
         logging.warning(f"Failed to read DICOM file {file_path}: {e}")
         return None
 
 
-def _aggregate_by_study(all_headers):
+def _aggregate_by_study(all_headers: list[dict[str, str]]) -> pd.DataFrame:
     df = pd.DataFrame(all_headers)
-    
+
     if df.empty:
         return df
-    
+
     if "StudyInstanceUID" not in df.columns:
         return df
-    
+
     study_groups = df.groupby("StudyInstanceUID", dropna=False)
     aggregated_data = []
-    
+
     for study_uid, group in study_groups:
         study_data = {}
         for col in group.columns:
@@ -66,30 +67,31 @@ def _aggregate_by_study(all_headers):
             else:
                 study_data[col] = ""
         aggregated_data.append(study_data)
-    
+
     return pd.DataFrame(aggregated_data)
 
 
-def headerextract_local(input_dir, output_dir, headers_to_extract=None,
-                     extract_all_headers=False, debug=False, run_dirs=None):
+def headerextract_local(input_dir: str, output_dir: str, headers_to_extract: list[str] | None = None,
+                     extract_all_headers: bool = False, debug: bool = False,
+                     run_dirs: RunDirs | None = None) -> HeaderExtractResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
-    
+
     logging.info("Starting header extraction")
     logging.info(f"Input directory: {input_dir}")
     logging.info(f"Output directory: {output_dir}")
     logging.info(f"Extract all headers: {extract_all_headers}")
-    
+
     os.makedirs(output_dir, exist_ok=True)
-    
+
     logging.info("Finding DICOM files...")
     dicom_files = _find_dicom_files(input_dir)
     total_files = len(dicom_files)
     logging.info(f"Found {format_number_with_commas(total_files)} DICOM files")
-    
+
     if headers_to_extract:
         logging.info(f"Extracting custom headers: {headers_to_extract}")
     elif extract_all_headers:
@@ -97,13 +99,13 @@ def headerextract_local(input_dir, output_dir, headers_to_extract=None,
         headers_to_extract = None
     else:
         raise ValueError("Must provide either headers_to_extract or set extract_all_headers=True")
-    
+
     if headers_to_extract and "StudyInstanceUID" not in headers_to_extract:
         headers_to_extract.append("StudyInstanceUID")
-    
-    all_headers = []
+
+    all_headers: list[dict[str, str]] = []
     files_processed = 0
-    
+
     for i, file_path in enumerate(dicom_files):
         if extract_all_headers:
             try:
@@ -123,27 +125,27 @@ def headerextract_local(input_dir, output_dir, headers_to_extract=None,
             except Exception as e:
                 logging.warning(f"Failed to read DICOM file {file_path}: {e}")
         else:
+            assert headers_to_extract is not None
             header_data = _extract_headers_from_file(file_path, headers_to_extract)
             if header_data:
                 all_headers.append(header_data)
                 files_processed += 1
-        
+
         if (i + 1) % 100 == 0:
             logging.info(f"Processed {format_number_with_commas(i + 1)} / {format_number_with_commas(total_files)} files")
-    
+
     logging.info("Aggregating headers by study...")
     df = _aggregate_by_study(all_headers)
-    
+
     metadata_path = os.path.join(output_dir, "metadata.xlsx")
     df.to_excel(metadata_path, index=False, engine='openpyxl')
     logging.info(f"Saved metadata to {metadata_path}")
-    
+
     logging.info("Header extraction complete")
     logging.info(f"Total files processed: {format_number_with_commas(files_processed)}")
     logging.info(f"Total studies: {len(df)}")
-    
+
     return {
         "num_files_processed": files_processed,
         "num_studies": len(df)
     }
-

--- a/module_image_export.py
+++ b/module_image_export.py
@@ -132,7 +132,7 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
             
             
             try:
-                result = subprocess.run(
+                subprocess.run(
                     cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,

--- a/module_image_export.py
+++ b/module_image_export.py
@@ -5,24 +5,24 @@ import sys
 import tempfile
 from urllib.parse import urlparse
 
-from utils import configure_run_logging, setup_run_directories
+from utils import RunDirs, configure_run_logging, setup_run_directories
 
 
-def _get_rclone_binary():
+def _get_rclone_binary() -> str:
     if getattr(sys, 'frozen', False):
         bundle_dir = os.path.abspath(os.path.dirname(sys.executable))
         rclone_binary = os.path.join(bundle_dir, '_internal', 'rclone', 'rclone')
     else:
         rclone_binary = os.path.join(os.path.dirname(__file__), 'rclone', 'rclone')
-    
+
     return rclone_binary
 
 
-def _parse_sas_url(sas_url):
+def _parse_sas_url(sas_url: str) -> tuple[str, str, str]:
     parsed = urlparse(sas_url)
 
     is_azurite = parsed.netloc.startswith('127.0.0.1') or parsed.netloc.startswith('localhost')
-    
+
     if is_azurite:
         path_parts = [p for p in parsed.path.split('/') if p]
         if len(path_parts) >= 2:
@@ -42,16 +42,16 @@ def _parse_sas_url(sas_url):
     return account_name, container_name, sas_token
 
 
-def _create_rclone_config(sas_url, config_path):
+def _create_rclone_config(sas_url: str, config_path: str) -> None:
     parsed = urlparse(sas_url)
 
     is_azurite = parsed.netloc.startswith('127.0.0.1') or parsed.netloc.startswith('localhost')
-    
+
     if is_azurite:
         path_parts = [p for p in parsed.path.split('/') if p]
         account_name = path_parts[0] if path_parts else "devstoreaccount1"
         endpoint = f"{parsed.scheme}://{parsed.netloc}/{account_name}"
-        
+
         config_content = f"""[azure]
             type = azureblob
             account = {account_name}
@@ -66,18 +66,20 @@ def _create_rclone_config(sas_url, config_path):
             account = {account_name}
             sas_url = {sas_url}
         """
-    
+
     with open(config_path, 'w') as f:
         f.write(config_content)
 
 
-def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False, run_dirs=None):
+def image_export(input_dir: str, sas_url: str, project_name: str,
+                 appdata_dir: str | None = None, debug: bool = False,
+                 run_dirs: RunDirs | None = None) -> dict[str, str]:
     """
     Export files from input directory to Azure Blob Storage using rclone.
-    
+
     All files are uploaded to the container with the path structure:
     {container}/{project_name}/{original_relative_path}
-    
+
     Args:
         input_dir: Input directory containing files to export
         sas_url: SAS URL for the Azure container (includes container name)
@@ -85,7 +87,7 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
         appdata_dir: Application data directory for logs
         debug: Enable debug logging
         run_dirs: Run directories dictionary (optional)
-        
+
     Returns:
         dict: Export statistics
     """
@@ -94,7 +96,7 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
 
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
-    
+
     logging.info("="*80)
     logging.info("IMAGE EXPORT MODULE (rclone)")
     logging.info("="*80)
@@ -102,22 +104,22 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
     logging.info(f"Project name: {project_name}")
     logging.info(f"SAS URL: {sas_url.split('?')[0]}...")
     logging.info("="*80)
-    
+
     if not os.path.exists(input_dir):
         raise Exception(f"Input directory does not exist: {input_dir}")
 
     if not os.listdir(input_dir):
         raise Exception(f"Input directory is empty: {input_dir}")
-    
+
     try:
         _, container_name, _ = _parse_sas_url(sas_url)
-        
+
         rclone_config_path = os.path.join(tempfile.gettempdir(), f"rclone_{os.getpid()}.conf")
         _create_rclone_config(sas_url, rclone_config_path)
-        
+
         try:
             destination = f"azure:{container_name}/{project_name}"
-            
+
             rclone_binary = _get_rclone_binary()
             cmd = [
                 rclone_binary,
@@ -127,10 +129,10 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
                 input_dir,
                 destination
             ]
-            
+
             logging.info(f"Running rclone command: {' '.join(cmd[:4])} ... {destination}")
-            
-            
+
+
             try:
                 subprocess.run(
                     cmd,
@@ -140,7 +142,7 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
                     check=True
                 )
                 logging.info("PROGRESS: COMPLETE")
-                
+
                 return {
                     "status": "completed"
                 }
@@ -149,22 +151,22 @@ def image_export(input_dir, sas_url, project_name, appdata_dir=None, debug=False
         finally:
             if os.path.exists(rclone_config_path):
                 os.remove(rclone_config_path)
-        
+
     except subprocess.CalledProcessError as e:
         error_parts = []
-        
+
         if e.stderr:
             error_parts.append(f"rclone stderr: {e.stderr}")
             logging.error(f"rclone stderr: {e.stderr}")
         if e.stdout:
             error_parts.append(f"rclone stdout: {e.stdout}")
             logging.error(f"rclone stdout: {e.stdout}")
-        
+
         error_details = '\n'.join(error_parts) if error_parts else str(e)
         error_msg = f"rclone error: Command failed with exit code {e.returncode}"
         if error_details:
             error_msg += f"\n{error_details}"
-        
+
         logging.error(error_msg)
 
         raise Exception(error_msg)

--- a/module_image_export.py
+++ b/module_image_export.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 from urllib.parse import urlparse
 
 from utils import configure_run_logging, setup_run_directories

--- a/module_imagedeid_local.py
+++ b/module_imagedeid_local.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import time
 import xml.etree.ElementTree as ET
 

--- a/module_imagedeid_local.py
+++ b/module_imagedeid_local.py
@@ -6,39 +6,39 @@ import xml.etree.ElementTree as ET
 import pandas as pd
 
 from ctp import CTPPipeline
-from utils import setup_run_directories, configure_run_logging, format_number_with_commas, count_dicom_files, csv_string_to_xlsx, combine_filters, validate_dicom_tags, detect_and_validate_dates, format_dicom_date
+from utils import ImageDeidLocalResult, RunDirs, setup_run_directories, configure_run_logging, format_number_with_commas, count_dicom_files, csv_string_to_xlsx, combine_filters, validate_dicom_tags, detect_and_validate_dates, format_dicom_date
 
 
-def _save_metadata_files(pipeline, appdata_dir):
+def _save_metadata_files(pipeline: CTPPipeline, appdata_dir: str) -> None:
     audit_log_csv = pipeline.get_audit_log_csv("AuditLog")
     if audit_log_csv:
         csv_string_to_xlsx(audit_log_csv, os.path.join(appdata_dir, "metadata.xlsx"))
-    
+
     deid_audit_log_csv = pipeline.get_audit_log_csv("DeidAuditLog")
     if deid_audit_log_csv:
         csv_string_to_xlsx(deid_audit_log_csv, os.path.join(appdata_dir, "deid_metadata.xlsx"))
-    
+
     linker_csv = pipeline.get_idmap_csv()
     if linker_csv:
         csv_string_to_xlsx(linker_csv, os.path.join(appdata_dir, "linker.xlsx"))
 
 
-def _log_progress(total_files, pipeline):
+def _log_progress(total_files: int, pipeline: CTPPipeline) -> None:
     if pipeline.metrics:
         files_received = pipeline.metrics.files_received
         files_quarantined = pipeline.metrics.files_quarantined
-        
+
         progress_msg = f"Processed {format_number_with_commas(files_received)} / {format_number_with_commas(total_files)} files"
         if files_quarantined > 0:
             progress_msg += f" ({format_number_with_commas(files_quarantined)} quarantined)"
-        
+
         logging.info(progress_msg)
 
 
-def _apply_default_filter_script(filter_script, apply_default_filter_script):
+def _apply_default_filter_script(filter_script: str | None, apply_default_filter_script: bool) -> str | None:
     if not apply_default_filter_script:
         return filter_script
-    
+
     stanford_filter_path = os.path.join(os.path.dirname(__file__), "ctp", "scripts", "stanford-filter.script")
     if os.path.exists(stanford_filter_path):
         with open(stanford_filter_path, 'r') as f:
@@ -49,35 +49,35 @@ def _apply_default_filter_script(filter_script, apply_default_filter_script):
         return filter_script
 
 
-def _generate_lookup_table_content(mapping_file_path):
+def _generate_lookup_table_content(mapping_file_path: str) -> str:
     df = pd.read_excel(mapping_file_path)
-    
+
     tag_mappings = {}
     for col in df.columns:
         if col.startswith("New-"):
             original_tag = col[4:]
             if original_tag in df.columns:
                 tag_mappings[original_tag] = col
-    
+
     if not tag_mappings:
         raise ValueError("Mapping file must have at least one New-{TagName} column with corresponding TagName column")
-    
+
     all_tags = list(tag_mappings.keys())
     validate_dicom_tags(all_tags)
-    
+
     date_tags = {}
     for tag in all_tags:
         if detect_and_validate_dates(df, tag):
             date_tags[tag] = True
-    
+
     lookup_lines = []
     for tag, new_tag_col in tag_mappings.items():
         is_date = tag in date_tags
-        
+
         for _, row in df.iterrows():
             original_value = row[tag]
             new_value = row[new_tag_col]
-            
+
             if pd.notna(original_value) and pd.notna(new_value):
                 if is_date:
                     original_value = format_dicom_date(original_value)
@@ -85,122 +85,124 @@ def _generate_lookup_table_content(mapping_file_path):
                 else:
                     original_value = str(original_value).strip()
                     new_value = str(new_value).strip()
-                
+
                 lookup_lines.append(f"{tag}/{original_value} = {new_value}")
-    
+
     return "\n".join(lookup_lines)
 
 
-def _parse_anonymizer_script_actions(anonymizer_script):
+def _parse_anonymizer_script_actions(anonymizer_script: str) -> dict[str, str]:
     tag_actions = {}
-    
+
     if not anonymizer_script:
         return tag_actions
-    
+
     try:
         root = ET.fromstring(anonymizer_script)
-        
+
         for elem in root.findall(".//e[@n]"):
             tag_name = elem.get("n")
             tag_text = elem.text
-            
+
             if tag_name and tag_text:
                 tag_actions[tag_name] = tag_text.strip()
-        
+
         return tag_actions
     except ET.ParseError as e:
         raise ValueError(f"Failed to parse anonymizer script XML: {e}")
 
 
-def _get_tag_hex_from_keyword(tag_keyword):
+def _get_tag_hex_from_keyword(tag_keyword: str) -> str | None:
     dictionary_path = os.path.join(os.path.dirname(__file__), "resources", "dictionary.xml")
     tree = ET.parse(dictionary_path)
     root = tree.getroot()
-    
+
     for element in root.findall(".//element[@key]"):
         if element.get("key") == tag_keyword:
             tag_attr = element.get("tag")
             if tag_attr:
                 tag_hex = tag_attr.replace("(", "").replace(")", "").replace(",", "")
                 return tag_hex
-    
+
     raise ValueError(f"Tag {tag_keyword} not found in DICOM dictionary")
 
 
-def _extract_simple_action(action_string):
+def _extract_simple_action(action_string: str) -> str | None:
     simple_actions = ["@keep()", "@remove()", "@empty()"]
-    
+
     for simple_action in simple_actions:
         if action_string == simple_action:
             return simple_action[1:-2]
-    
+
     return "quarantine"
 
 
-def _merge_mapping_with_script(mapping_file_path, anonymizer_script):
+def _merge_mapping_with_script(mapping_file_path: str, anonymizer_script: str) -> str:
     df = pd.read_excel(mapping_file_path)
-    
+
     tag_mappings = {}
     for col in df.columns:
         if col.startswith("New-"):
             original_tag = col[4:]
             if original_tag in df.columns:
                 tag_mappings[original_tag] = col
-    
+
     existing_actions = _parse_anonymizer_script_actions(anonymizer_script)
-    
+
     try:
         root = ET.fromstring(anonymizer_script)
     except ET.ParseError:
         root = ET.Element("script")
-    
+
     for tag_name in tag_mappings.keys():
         tag_hex = _get_tag_hex_from_keyword(tag_name)
-        
+
         existing_elem = None
         for elem in root.findall(f".//e[@n='{tag_name}']"):
             existing_elem = elem
             break
-        
+
         if existing_elem is not None:
             original_action = existing_actions.get(tag_name, "@keep()")
             simple_fallback = _extract_simple_action(original_action)
             new_action = f"@lookup(this,{tag_name},{simple_fallback})"
             existing_elem.text = new_action
-        else:
+        elif tag_hex is not None:
             new_elem = ET.Element("e")
             new_elem.set("en", "T")
             new_elem.set("t", tag_hex)
             new_elem.set("n", tag_name)
             new_elem.text = f"@lookup(this,{tag_name},keep)"
             root.append(new_elem)
-    
+
     return ET.tostring(root, encoding="unicode")
 
 
-def _process_mapping_file(mapping_file_path, anonymizer_script, lookup_table):
+def _process_mapping_file(mapping_file_path: str | None, anonymizer_script: str | None, lookup_table: str | None) -> tuple[str | None, str | None]:
     if lookup_table is not None:
         return lookup_table, anonymizer_script
-    
+
     if not mapping_file_path:
         return None, anonymizer_script
-    
+
     lookup_content = _generate_lookup_table_content(mapping_file_path)
+    if anonymizer_script is None:
+        return lookup_content, None
     modified_script = _merge_mapping_with_script(mapping_file_path, anonymizer_script)
-    
+
     return lookup_content, modified_script
 
 
-def imagedeid_local(input_dir, output_dir, appdata_dir=None, filter_script=None,
-                   anonymizer_script=None, deid_pixels=False, lookup_table=None,
-                   debug=False, run_dirs=None, apply_default_filter_script=True,
-                   mapping_file_path=None, sc_pdf_output_dir=None):
+def imagedeid_local(input_dir: str, output_dir: str, appdata_dir: str | None = None, filter_script: str | None = None,
+                   anonymizer_script: str | None = None, deid_pixels: bool = False, lookup_table: str | None = None,
+                   debug: bool = False, run_dirs: RunDirs | None = None, apply_default_filter_script: bool = True,
+                   mapping_file_path: str | None = None, sc_pdf_output_dir: str | None = None) -> ImageDeidLocalResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
-    
+
     logging.info("Starting image deidentification")
     logging.info(f"Input directory: {input_dir}")
     logging.info(f"Output directory: {output_dir}")
@@ -213,20 +215,20 @@ def imagedeid_local(input_dir, output_dir, appdata_dir=None, filter_script=None,
     if mapping_file_path:
         logging.info(f"Mapping file: {mapping_file_path}")
     logging.info(f"Pixel deidentification: {'enabled' if deid_pixels else 'disabled'}")
-    
+
     logging.info("Counting input files...")
     total_files = count_dicom_files(input_dir)
     logging.info(f"Found {format_number_with_commas(total_files)} files to process")
-    
+
     if appdata_dir is None:
         appdata_dir = run_dirs["appdata_dir"]
-    
+
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(appdata_dir, exist_ok=True)
-    
+
     quarantine_dir = os.path.join(appdata_dir, "quarantine")
     os.makedirs(quarantine_dir, exist_ok=True)
-    
+
     if anonymizer_script is None and mapping_file_path:
         default_script_path = os.path.join(os.path.dirname(__file__), "ctp", "scripts", "DicomAnonymizer.script")
         if os.path.exists(default_script_path):
@@ -234,21 +236,21 @@ def imagedeid_local(input_dir, output_dir, appdata_dir=None, filter_script=None,
                 anonymizer_script = f.read()
         else:
             raise ValueError(f"Default anonymizer script not found at {default_script_path}")
-    
+
     processed_lookup_table, processed_anonymizer_script = _process_mapping_file(
         mapping_file_path, anonymizer_script, lookup_table
     )
-    
+
     if processed_lookup_table is not None:
         lookup_table = processed_lookup_table
     if processed_anonymizer_script is not None:
         anonymizer_script = processed_anonymizer_script
-    
+
     final_filter_script = _apply_default_filter_script(filter_script, apply_default_filter_script)
-    
+
     pipeline_type = "imagedeid_local_pixel" if deid_pixels else "imagedeid_local"
     ctp_log_level = "DEBUG" if debug else None
-    
+
     with CTPPipeline(
         pipeline_type=pipeline_type,
         output_dir=output_dir,
@@ -262,31 +264,30 @@ def imagedeid_local(input_dir, output_dir, appdata_dir=None, filter_script=None,
         sc_pdf_output_dir=sc_pdf_output_dir,
     ) as pipeline:
         time.sleep(3)
-        
+
         save_interval = 5
         last_save_time = 0
-        
+
         while not pipeline.is_complete():
             current_time = time.time()
             if current_time - last_save_time >= save_interval:
                 _save_metadata_files(pipeline, appdata_dir)
                 _log_progress(total_files, pipeline)
                 last_save_time = current_time
-            
+
             time.sleep(1)
-        
+
         _save_metadata_files(pipeline, appdata_dir)
-        
+
         num_saved = pipeline.metrics.files_saved if pipeline.metrics else 0
         num_quarantined = pipeline.metrics.files_quarantined if pipeline.metrics else 0
-        
+
         logging.info("Deidentification complete")
         logging.info(f"Total files processed: {format_number_with_commas(num_saved + num_quarantined)}")
         logging.info(f"Files saved: {format_number_with_commas(num_saved)}")
         logging.info(f"Files quarantined: {format_number_with_commas(num_quarantined)}")
-        
+
         return {
             "num_images_saved": num_saved,
             "num_images_quarantined": num_quarantined
         }
-

--- a/module_imagedeid_pacs.py
+++ b/module_imagedeid_pacs.py
@@ -5,48 +5,54 @@ import time
 
 from ctp import CTPPipeline
 from module_imagedeid_local import _save_metadata_files, _apply_default_filter_script, _process_mapping_file
-from utils import (generate_queries_and_filter,
+from utils import (PacsConfiguration, PacsQueryResult, RunDirs, Spreadsheet,
+                   generate_queries_and_filter,
                    combine_filters, validate_date_window_days, find_valid_pacs_list,
                    find_studies_from_pacs_list,
                    get_studies_from_study_pacs_map, setup_run_directories, configure_run_logging,
                    format_number_with_commas, save_failed_queries_csv)
 
 
-def _log_progress(pipeline):
+def _log_progress(pipeline: CTPPipeline) -> None:
     if pipeline.metrics:
         files_received = pipeline.metrics.files_received
         files_quarantined = pipeline.metrics.files_quarantined
-        
+
         progress_msg = f"Processed {format_number_with_commas(files_received)} files"
         if files_quarantined > 0:
             progress_msg += f" ({format_number_with_commas(files_quarantined)} quarantined)"
-        
+
         logging.info(progress_msg)
 
 
-def imagedeid_pacs(pacs_list, query_spreadsheet, application_aet,
-                   output_dir, appdata_dir=None, filter_script=None,
-                   date_window_days=0, anonymizer_script=None, deid_pixels=False,
-                   lookup_table=None, debug=False, run_dirs=None, apply_default_filter_script=True,
-                   mapping_file_path=None, sc_pdf_output_dir=None, use_fallback_query=False):
+def imagedeid_pacs(pacs_list: list[PacsConfiguration], query_spreadsheet: Spreadsheet,
+                   application_aet: str, output_dir: str,
+                   appdata_dir: str | None = None, filter_script: str | None = None,
+                   date_window_days: int = 0, anonymizer_script: str | None = None,
+                   deid_pixels: bool = False, lookup_table: str | None = None,
+                   debug: bool = False, run_dirs: RunDirs | None = None,
+                   apply_default_filter_script: bool = True,
+                   mapping_file_path: str | None = None,
+                   sc_pdf_output_dir: str | None = None,
+                   use_fallback_query: bool = False) -> PacsQueryResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
     logging.info(f"Running imagedeid_pacs (use_fallback_query={use_fallback_query})")
-    
+
     if appdata_dir is None:
         appdata_dir = run_dirs["appdata_dir"]
-    
+
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(appdata_dir, exist_ok=True)
-    
+
     quarantine_dir = os.path.join(appdata_dir, "quarantine")
     os.makedirs(quarantine_dir, exist_ok=True)
-    
+
     validate_date_window_days(date_window_days)
-    
+
     if anonymizer_script is None and mapping_file_path:
         default_script_path = os.path.join(os.path.dirname(__file__), "ctp", "scripts", "DicomAnonymizer.script")
         if os.path.exists(default_script_path):
@@ -54,16 +60,16 @@ def imagedeid_pacs(pacs_list, query_spreadsheet, application_aet,
                 anonymizer_script = f.read()
         else:
             raise ValueError(f"Default anonymizer script not found at {default_script_path}")
-    
+
     processed_lookup_table, processed_anonymizer_script = _process_mapping_file(
         mapping_file_path, anonymizer_script, lookup_table
     )
-    
+
     if processed_lookup_table is not None:
         lookup_table = processed_lookup_table
     if processed_anonymizer_script is not None:
         anonymizer_script = processed_anonymizer_script
-    
+
     query_params_list, expected_values_list, generated_filter = generate_queries_and_filter(
         query_spreadsheet, date_window_days, use_fallback_query=use_fallback_query)
     combined_filter = combine_filters(filter_script, generated_filter)
@@ -93,10 +99,10 @@ def imagedeid_pacs(pacs_list, query_spreadsheet, application_aet,
         # Choose pipeline type based on whether pixel de-identification is needed
         pipeline_type = "imagedeid_pacs_pixel" if deid_pixels else "imagedeid_pacs"
         ctp_log_level = "DEBUG" if debug else None
-    
+
         # Retrieve files BEFORE starting CTP so ArchiveImportService finds them on initial scan
         successful_gets, failed_get_indices, failed_get_details = get_studies_from_study_pacs_map(study_pacs_map, application_aet, getscu_output_dir)
-    
+
         # Wait briefly to ensure all files are written
         time.sleep(2)
 

--- a/module_imagedeidexport.py
+++ b/module_imagedeidexport.py
@@ -3,29 +3,33 @@ import os
 
 from module_imagedeid_pacs import imagedeid_pacs
 from module_image_export import image_export
-from utils import setup_run_directories, configure_run_logging
+from utils import DeidExportResult, PacsConfiguration, RunDirs, Spreadsheet, setup_run_directories, configure_run_logging
 
 
-def imagedeidexport(pacs_list, query_spreadsheet, application_aet,
-                    sas_url, project_name, output_dir, appdata_dir=None,
-                    filter_script=None, date_window_days=0,
-                    anonymizer_script=None, deid_pixels=False,
-                    lookup_table=None, debug=False, run_dirs=None,
-                    apply_default_filter_script=True, mapping_file_path=None,
-                    sc_pdf_output_dir=None, use_fallback_query=False):
+def imagedeidexport(pacs_list: list[PacsConfiguration], query_spreadsheet: Spreadsheet,
+                    application_aet: str, sas_url: str, project_name: str,
+                    output_dir: str, appdata_dir: str | None = None,
+                    filter_script: str | None = None, date_window_days: int = 0,
+                    anonymizer_script: str | None = None, deid_pixels: bool = False,
+                    lookup_table: str | None = None, debug: bool = False,
+                    run_dirs: RunDirs | None = None,
+                    apply_default_filter_script: bool = True,
+                    mapping_file_path: str | None = None,
+                    sc_pdf_output_dir: str | None = None,
+                    use_fallback_query: bool = False) -> DeidExportResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
     logging.info("Running imagedeidexport")
-    
+
     if appdata_dir is None:
         appdata_dir = run_dirs["appdata_dir"]
-    
+
     os.makedirs(appdata_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
-    
+
     deid_result = imagedeid_pacs(
         pacs_list=pacs_list,
         query_spreadsheet=query_spreadsheet,
@@ -44,7 +48,7 @@ def imagedeidexport(pacs_list, query_spreadsheet, application_aet,
         sc_pdf_output_dir=sc_pdf_output_dir,
         use_fallback_query=use_fallback_query
     )
-    
+
     if deid_result["num_images_saved"] > 0:
         image_export(
             input_dir=output_dir,
@@ -54,14 +58,13 @@ def imagedeidexport(pacs_list, query_spreadsheet, application_aet,
             debug=debug,
             run_dirs=run_dirs
         )
-    
+
     logging.info("Deidentification and export complete")
     logging.info(f"Deidentified files preserved at: {output_dir}")
-    
+
     return {
         "num_studies_found": deid_result["num_studies_found"],
         "num_images_exported": deid_result["num_images_saved"],
         "num_images_quarantined": deid_result["num_images_quarantined"],
         "failed_query_indices": deid_result["failed_query_indices"]
     }
-

--- a/module_imageqr.py
+++ b/module_imageqr.py
@@ -4,7 +4,8 @@ import shutil
 import time
 
 from ctp import CTPPipeline
-from utils import (generate_queries_and_filter, combine_filters,
+from utils import (PacsConfiguration, PacsQueryResult, RunDirs, Spreadsheet,
+                   generate_queries_and_filter, combine_filters,
                    validate_date_window_days, find_valid_pacs_list,
                    find_studies_from_pacs_list,
                    get_studies_from_study_pacs_map,
@@ -12,45 +13,48 @@ from utils import (generate_queries_and_filter, combine_filters,
                    format_number_with_commas, csv_string_to_xlsx, save_failed_queries_csv)
 
 
-def _save_metadata_files(pipeline, appdata_dir):
+def _save_metadata_files(pipeline: CTPPipeline, appdata_dir: str) -> None:
     audit_log_csv = pipeline.get_audit_log_csv("AuditLog")
     if audit_log_csv:
         csv_string_to_xlsx(audit_log_csv, os.path.join(appdata_dir, "metadata.xlsx"))
 
 
-def _log_progress(pipeline):
+def _log_progress(pipeline: CTPPipeline) -> None:
     if pipeline.metrics:
         files_received = pipeline.metrics.files_received
         files_quarantined = pipeline.metrics.files_quarantined
-        
+
         progress_msg = f"Processed {format_number_with_commas(files_received)} files"
         if files_quarantined > 0:
             progress_msg += f" ({format_number_with_commas(files_quarantined)} quarantined)"
-        
+
         logging.info(progress_msg)
 
 
-def imageqr(pacs_list, query_spreadsheet, application_aet,
-            output_dir, appdata_dir=None, filter_script=None, date_window_days=0,
-            debug=False, run_dirs=None, use_fallback_query=False):
+def imageqr(pacs_list: list[PacsConfiguration], query_spreadsheet: Spreadsheet,
+            application_aet: str, output_dir: str,
+            appdata_dir: str | None = None, filter_script: str | None = None,
+            date_window_days: int = 0, debug: bool = False,
+            run_dirs: RunDirs | None = None,
+            use_fallback_query: bool = False) -> PacsQueryResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
     logging.info(f"Running imageqr (use_fallback_query={use_fallback_query})")
-    
+
     if appdata_dir is None:
         appdata_dir = run_dirs["appdata_dir"]
-    
+
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(appdata_dir, exist_ok=True)
-    
+
     quarantine_dir = os.path.join(appdata_dir, "quarantine")
     os.makedirs(quarantine_dir, exist_ok=True)
-    
+
     validate_date_window_days(date_window_days)
-    
+
     query_params_list, expected_values_list, generated_filter = generate_queries_and_filter(
         query_spreadsheet, date_window_days, use_fallback_query=use_fallback_query)
     combined_filter = combine_filters(filter_script, generated_filter)
@@ -68,10 +72,10 @@ def imageqr(pacs_list, query_spreadsheet, application_aet,
 
     try:
         ctp_log_level = "DEBUG" if debug else None
-    
+
         # Retrieve files BEFORE starting CTP so ArchiveImportService finds them on initial scan
         successful_gets, failed_get_indices, get_failure_details = get_studies_from_study_pacs_map(study_pacs_map, application_aet, getscu_output_dir)
-    
+
         # Wait briefly to ensure all files are written
         time.sleep(2)
 
@@ -127,4 +131,3 @@ def imageqr(pacs_list, query_spreadsheet, application_aet,
             shutil.rmtree(getscu_output_dir)
         except OSError as e:
             logging.warning("Failed to remove temporary getscu directory '%s': %s", getscu_output_dir, e)
-

--- a/module_singleclickicore.py
+++ b/module_singleclickicore.py
@@ -4,26 +4,32 @@ import os
 from module_imagedeid_pacs import imagedeid_pacs
 from module_textdeid import textdeid
 from module_image_export import image_export
-from utils import setup_run_directories, configure_run_logging
+from utils import PacsConfiguration, RunDirs, SingleClickResult, Spreadsheet, setup_run_directories, configure_run_logging
 
 
-def singleclickicore(pacs_list, query_spreadsheet, application_aet,
-                     sas_url, project_name, output_dir, input_file,
-                     appdata_dir=None,
-                     filter_script=None, date_window_days=0,
-                     anonymizer_script=None, deid_pixels=False,
-                     lookup_table=None, apply_default_filter_script=True,
-                     mapping_file_path=None,
-                     to_keep_list=None, to_remove_list=None,
-                     columns_to_drop=None, columns_to_deid=None,
-                     debug=False, run_dirs=None, skip_export=False,
-                     sc_pdf_output_dir=None, use_fallback_query=False):
+def singleclickicore(pacs_list: list[PacsConfiguration], query_spreadsheet: Spreadsheet,
+                     application_aet: str, sas_url: str | None, project_name: str,
+                     output_dir: str, input_file: str,
+                     appdata_dir: str | None = None,
+                     filter_script: str | None = None, date_window_days: int = 0,
+                     anonymizer_script: str | None = None, deid_pixels: bool = False,
+                     lookup_table: str | None = None,
+                     apply_default_filter_script: bool = True,
+                     mapping_file_path: str | None = None,
+                     to_keep_list: list[str] | None = None,
+                     to_remove_list: list[str] | None = None,
+                     columns_to_drop: list[str] | None = None,
+                     columns_to_deid: list[str] | None = None,
+                     debug: bool = False, run_dirs: RunDirs | None = None,
+                     skip_export: bool = False,
+                     sc_pdf_output_dir: str | None = None,
+                     use_fallback_query: bool = False) -> SingleClickResult:
     """
     Combined module that performs:
     1. Image deidentification from PACS (HIPAA Safe Harbor enforced)
     2. Text deidentification on input Excel file
     3. Export of all output to Azure Blob Storage (optional)
-    
+
     Args:
         pacs_list: List of PacsConfiguration objects
         query_spreadsheet: Spreadsheet object for PACS querying
@@ -47,7 +53,7 @@ def singleclickicore(pacs_list, query_spreadsheet, application_aet,
         debug: Enable debug logging
         run_dirs: Run directories dictionary
         skip_export: Whether to skip Azure export (default: False)
-        
+
     Returns:
         dict: Combined results from all steps
 
@@ -57,22 +63,22 @@ def singleclickicore(pacs_list, query_spreadsheet, application_aet,
     """
     if run_dirs is None:
         run_dirs = setup_run_directories()
-    
+
     log_level = logging.DEBUG if debug else logging.INFO
     configure_run_logging(run_dirs["run_log_path"], log_level)
     logging.info("Running singleclickicore")
-    
+
     if appdata_dir is None:
         appdata_dir = run_dirs["appdata_dir"]
-    
+
     os.makedirs(appdata_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Step 1: Image deid from PACS
     logging.info("="*80)
     logging.info("STEP 1: Image Deidentification from PACS")
     logging.info("="*80)
-    
+
     deid_result = imagedeid_pacs(
         pacs_list=pacs_list,
         query_spreadsheet=query_spreadsheet,
@@ -91,12 +97,12 @@ def singleclickicore(pacs_list, query_spreadsheet, application_aet,
         sc_pdf_output_dir=sc_pdf_output_dir,
         use_fallback_query=use_fallback_query
     )
-    
+
     # Step 2: Text deid on input Excel
     logging.info("="*80)
     logging.info("STEP 2: Text Deidentification on Input File")
     logging.info("="*80)
-    
+
     text_result = textdeid(
         input_file=input_file,
         output_dir=output_dir,
@@ -107,13 +113,16 @@ def singleclickicore(pacs_list, query_spreadsheet, application_aet,
         debug=debug,
         run_dirs=run_dirs
     )
-    
+
     # Step 3: Export to Azure (only if we have content to export and not skipped)
     if not skip_export:
         logging.info("="*80)
         logging.info("STEP 3: Export to Azure Blob Storage")
         logging.info("="*80)
-        
+
+        if sas_url is None:
+            raise ValueError("sas_url is required when skip_export is False")
+
         if deid_result["num_images_saved"] > 0 or text_result["num_rows_processed"] > 0:
             image_export(
                 input_dir=output_dir,
@@ -129,12 +138,12 @@ def singleclickicore(pacs_list, query_spreadsheet, application_aet,
         logging.info("="*80)
         logging.info("STEP 3: Export to Azure Blob Storage - SKIPPED")
         logging.info("="*80)
-    
+
     logging.info("="*80)
     logging.info("singleclickicore complete")
     logging.info(f"Deidentified files preserved at: {output_dir}")
     logging.info("="*80)
-    
+
     return {
         "num_studies_found": deid_result["num_studies_found"],
         "num_images_exported": deid_result["num_images_saved"],

--- a/module_textdeid.py
+++ b/module_textdeid.py
@@ -62,7 +62,6 @@ def create_nlp_engine():
         if model_subdir is None:
             raise FileNotFoundError(f"en_core_web_sm model not found in {models_base_dir}")
         model_path = model_subdir
-        import spacy
         from presidio_analyzer.nlp_engine import SpacyNlpEngine
         nlp_engine = SpacyNlpEngine(models=[{"lang_code": "en", "model_name": model_path}])
     else:

--- a/module_textdeid.py
+++ b/module_textdeid.py
@@ -4,11 +4,12 @@ import string
 import sys
 import pandas as pd
 import logging
+from typing import Any
 from presidio_analyzer import AnalyzerEngine, PatternRecognizer, Pattern
-from presidio_analyzer.nlp_engine import NlpEngineProvider
+from presidio_analyzer.nlp_engine import NlpEngineProvider, NlpEngine
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import OperatorConfig
-from utils import setup_run_directories, configure_run_logging
+from utils import RunDirs, TextDeidResult, setup_run_directories, configure_run_logging
 
 logging.getLogger("presidio-analyzer").setLevel(logging.ERROR)
 logging.getLogger("presidio-anonymizer").setLevel(logging.ERROR)
@@ -48,7 +49,7 @@ NLM_PRESERVE_MEDICAL = {
 
 NLM_REDACT_NAMES = {'pine'}
 
-def create_nlp_engine():
+def create_nlp_engine() -> NlpEngine:
     if getattr(sys, 'frozen', False):
         bundle_dir = os.path.abspath(os.path.dirname(sys.executable))
         models_base_dir = os.path.join(bundle_dir, '_internal', 'en_core_web_sm')
@@ -73,7 +74,7 @@ def create_nlp_engine():
         nlp_engine = provider.create_engine()
     return nlp_engine
 
-def create_analyzer_engine():
+def create_analyzer_engine() -> AnalyzerEngine:
     nlp_engine = create_nlp_engine()
     analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=["en"])
     
@@ -185,7 +186,7 @@ def create_analyzer_engine():
     
     return analyzer
 
-def scrub(data, whitelist, blacklist):
+def scrub(data: list[Any], whitelist: list[str], blacklist: list[str]) -> list[str]:
     analyzer = create_analyzer_engine()
     anonymizer = AnonymizerEngine()
     
@@ -331,8 +332,11 @@ def scrub(data, whitelist, blacklist):
     
     return results
 
-def textdeid(input_file, output_dir, to_keep_list=None, to_remove_list=None,
-             columns_to_drop=None, columns_to_deid=None, debug=False, run_dirs=None):
+def textdeid(input_file: str, output_dir: str, to_keep_list: list[str] | None = None,
+             to_remove_list: list[str] | None = None,
+             columns_to_drop: list[str] | None = None,
+             columns_to_deid: list[str] | None = None, debug: bool = False,
+             run_dirs: RunDirs | None = None) -> TextDeidResult:
     if run_dirs is None:
         run_dirs = setup_run_directories()
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "django-types>=0.23.0",
+    "ruff>=0.15.7",
     "ty>=0.0.25",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "django-types>=0.23.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.15.7",
     "ty>=0.0.25",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,9 @@ dependencies = [
     "zipp>=3.23.0",
 ]
 
+[dependency-groups]
+dev = [
+    "django-types>=0.23.0",
+    "ty>=0.0.25",
+]
+

--- a/test_cli.py
+++ b/test_cli.py
@@ -1,8 +1,6 @@
 import os
-import tempfile
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 from cli import (
     determine_module,
@@ -15,7 +13,7 @@ from cli import (
     build_imagedeidexport_params,
     run
 )
-from utils import PacsConfiguration, Spreadsheet
+from utils import PacsConfiguration
 
 
 def test_determine_module_imageqr(tmp_path):

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -317,7 +317,7 @@ def test_pacs_pipeline_dicom_port_conflict(tmp_path):
         application_aet="TEST",
         dicom_port=11112,
         source_ctp_dir=str(source_ctp)
-    ) as pipeline1:
+    ) as _pipeline1:
         time.sleep(3)
 
         with pytest.raises(DicomPortInUseError, match="DICOM port 11112"):
@@ -327,7 +327,7 @@ def test_pacs_pipeline_dicom_port_conflict(tmp_path):
                 application_aet="TEST",
                 dicom_port=11112,
                 source_ctp_dir=str(source_ctp)
-            ) as pipeline2:
+            ) as _pipeline2:
                 pass
 
 

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -21,7 +21,7 @@ from pydicom.uid import (
 from ctp import CTPServer, CTPPipeline, PIPELINE_TEMPLATES
 from dcmtk import get_study
 from module_imagedeid_local import imagedeid_local
-from test_utils import Fixtures, OrthancServer
+from test_utils import Fixtures
 
 
 CT_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.2"
@@ -893,7 +893,7 @@ def test_pipeline_auto_cleanup(tmp_path):
     assert not os.path.exists(tempdir_path)
 
 
-def test_imageqr_pipeline(tmp_path):
+def test_imageqr_pipeline(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
 
@@ -903,362 +903,325 @@ def test_imageqr_pipeline(tmp_path):
     input_dir.mkdir()
     output_dir.mkdir()
 
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i in range(10):
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"P{i:03d}",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality="CT"
+        )
+        ds.SeriesNumber = (i % 2) + 1
+        ds.InstanceNumber = i + 1
 
-    try:
-        for i in range(10):
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"P{i:03d}",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality="CT"
-            )
-            ds.SeriesNumber = (i % 2) + 1
-            ds.InstanceNumber = i + 1
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
 
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
+    source_ctp = Path(__file__).parent / "ctp"
 
-        source_ctp = Path(__file__).parent / "ctp"
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+    input_files = list(Path(input_dir).glob("*.dcm"))
+    print(f"Files retrieved to input_dir (*.dcm): {len(input_files)}")
 
-        input_files = list(Path(input_dir).glob("*.dcm"))
-        print(f"Files retrieved to input_dir (*.dcm): {len(input_files)}")
+    time.sleep(2)
 
-        time.sleep(2)
+    with CTPPipeline(
+        pipeline_type="imageqr",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
 
-        with CTPPipeline(
-            pipeline_type="imageqr",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-
-            images_dir = Path(output_dir) / "images"
-            output_files = list(images_dir.rglob("*.dcm"))
-            print(f"Files in output images_dir: {len(output_files)}")
-            assert len(output_files) >= 9
-    
-    finally:
-        orthanc.stop()
+        images_dir = Path(output_dir) / "images"
+        output_files = list(images_dir.rglob("*.dcm"))
+        print(f"Files in output images_dir: {len(output_files)}")
+        assert len(output_files) >= 9
 
 
-def test_imageqr_with_filter(tmp_path):
+def test_imageqr_with_filter(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(6):
-            modality = "CT" if i < 3 else "MR"
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"P{i:03d}",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality=modality
-            )
-            ds.SeriesNumber = 1
-            ds.InstanceNumber = i + 1
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    for i in range(6):
+        modality = "CT" if i < 3 else "MR"
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"P{i:03d}",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality=modality
+        )
+        ds.SeriesNumber = 1
+        ds.InstanceNumber = i + 1
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+    source_ctp = Path(__file__).parent / "ctp"
 
-        time.sleep(2)
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        with CTPPipeline(
-            pipeline_type="imageqr",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            filter_script='Modality.contains("CT")',
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            images_dir = Path(output_dir) / "images"
-            output_files = list(images_dir.rglob("*.dcm"))
-            assert len(output_files) == 3, f"Expected 3 CT files in output, got {len(output_files)}"
-            
-            for file in output_files:
-                ds = pydicom.dcmread(file)
-                assert ds.Modality == "CT", f"Expected CT modality, got {ds.Modality}"
-            
-            assert pipeline.metrics.files_quarantined == 3, f"Expected 3 MR files quarantined, got {pipeline.metrics.files_quarantined}"
-    
-    finally:
-        orthanc.stop()
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+
+    time.sleep(2)
+
+    with CTPPipeline(
+        pipeline_type="imageqr",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        filter_script='Modality.contains("CT")',
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
+
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        images_dir = Path(output_dir) / "images"
+        output_files = list(images_dir.rglob("*.dcm"))
+        assert len(output_files) == 3, f"Expected 3 CT files in output, got {len(output_files)}"
+
+        for file in output_files:
+            ds = pydicom.dcmread(file)
+            assert ds.Modality == "CT", f"Expected CT modality, got {ds.Modality}"
+
+        assert pipeline.metrics.files_quarantined == 3, f"Expected 3 MR files quarantined, got {pipeline.metrics.files_quarantined}"
 
 
-def test_imagedeid_pacs_pipeline(tmp_path):
+def test_imagedeid_pacs_pipeline(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(10):
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"P{i:03d}",
-                patient_name=f"Patient{i}^Test",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality="CT"
-            )
-            ds.SeriesNumber = (i % 2) + 1
-            ds.InstanceNumber = i + 1
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
 
-        anonymizer_script = """<script>
+    for i in range(10):
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"P{i:03d}",
+            patient_name=f"Patient{i}^Test",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality="CT"
+        )
+        ds.SeriesNumber = (i % 2) + 1
+        ds.InstanceNumber = i + 1
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
+
+    source_ctp = Path(__file__).parent / "ctp"
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
 
-        time.sleep(2)
+    time.sleep(2)
 
-        with CTPPipeline(
-            pipeline_type="imagedeid_pacs",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            anonymizer_script=anonymizer_script,
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
+    with CTPPipeline(
+        pipeline_type="imagedeid_pacs",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        anonymizer_script=anonymizer_script,
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            output_files = list(output_dir.rglob("*.dcm"))
-            assert len(output_files) >= 9
-    
-    finally:
-        orthanc.stop()
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        output_files = list(output_dir.rglob("*.dcm"))
+        assert len(output_files) >= 9
 
 
-def test_imagedeid_pacs_with_filter(tmp_path):
+def test_imagedeid_pacs_with_filter(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(6):
-            modality = "CT" if i < 3 else "MR"
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"P{i:03d}",
-                patient_name=f"Patient{i}^Test",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality=modality
-            )
-            ds.SeriesNumber = 1
-            ds.InstanceNumber = i + 1
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
 
-        anonymizer_script = """<script>
+    for i in range(6):
+        modality = "CT" if i < 3 else "MR"
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"P{i:03d}",
+            patient_name=f"Patient{i}^Test",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality=modality
+        )
+        ds.SeriesNumber = 1
+        ds.InstanceNumber = i + 1
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
+
+    source_ctp = Path(__file__).parent / "ctp"
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
 
-        time.sleep(2)
+    time.sleep(2)
 
-        with CTPPipeline(
-            pipeline_type="imagedeid_pacs",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            anonymizer_script=anonymizer_script,
-            filter_script='Modality.contains("CT")',
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 120
+    with CTPPipeline(
+        pipeline_type="imagedeid_pacs",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        anonymizer_script=anonymizer_script,
+        filter_script='Modality.contains("CT")',
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 120
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            output_files = list(output_dir.rglob("*.dcm"))
-            assert len(output_files) == 3, f"Expected 3 CT files in output, got {len(output_files)}"
-            
-            for file in output_files:
-                ds = pydicom.dcmread(file)
-                assert ds.Modality == "CT", f"Only CT files should be in output, found {ds.Modality}"
-                assert ds.PatientName == "", f"PatientName should be anonymized, got '{ds.PatientName}'"
-            
-            assert pipeline.metrics.files_saved == 3, "Expected 3 CT files saved"
-            assert pipeline.metrics.files_quarantined == 3, "Expected 3 MR files quarantined"
-            assert pipeline.metrics.files_received == 6, "Expected 6 files received"
-    
-    finally:
-        orthanc.stop()
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        output_files = list(output_dir.rglob("*.dcm"))
+        assert len(output_files) == 3, f"Expected 3 CT files in output, got {len(output_files)}"
+
+        for file in output_files:
+            ds = pydicom.dcmread(file)
+            assert ds.Modality == "CT", f"Only CT files should be in output, found {ds.Modality}"
+            assert ds.PatientName == "", f"PatientName should be anonymized, got '{ds.PatientName}'"
+
+        assert pipeline.metrics.files_saved == 3, "Expected 3 CT files saved"
+        assert pipeline.metrics.files_quarantined == 3, "Expected 3 MR files quarantined"
+        assert pipeline.metrics.files_received == 6, "Expected 6 files received"
 
 
-def test_imagedeid_pacs_with_anonymizer_script(tmp_path):
+def test_imagedeid_pacs_with_anonymizer_script(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(10):
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"MRN{i:04d}",
-                patient_name=f"Smith^John{i}",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality="CT"
-            )
-            ds.InstitutionName = "Test Hospital"
-            ds.ReferringPhysicianName = "Dr. Referring"
-            ds.Manufacturer = "TestManufacturer"
-            ds.ManufacturerModelName = "TestModel"
-            ds.SeriesNumber = (i % 2) + 1
-            ds.InstanceNumber = i + 1
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
 
-        anonymizer_script = """<script>
+    for i in range(10):
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"MRN{i:04d}",
+            patient_name=f"Smith^John{i}",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality="CT"
+        )
+        ds.InstitutionName = "Test Hospital"
+        ds.ReferringPhysicianName = "Dr. Referring"
+        ds.Manufacturer = "TestManufacturer"
+        ds.ManufacturerModelName = "TestModel"
+        ds.SeriesNumber = (i % 2) + 1
+        ds.InstanceNumber = i + 1
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
+
+    source_ctp = Path(__file__).parent / "ctp"
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080080" n="InstitutionName">@remove()</e>
@@ -1268,158 +1231,147 @@ def test_imagedeid_pacs_with_anonymizer_script(tmp_path):
 <e en="T" t="00080060" n="Modality">@keep()</e>
 </script>"""
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
 
-        time.sleep(2)
+    time.sleep(2)
 
-        with CTPPipeline(
-            pipeline_type="imagedeid_pacs",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            anonymizer_script=anonymizer_script,
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
+    with CTPPipeline(
+        pipeline_type="imagedeid_pacs",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        anonymizer_script=anonymizer_script,
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            output_files = list(output_dir.rglob("*.dcm"))
-            assert len(output_files) >= 9
-            
-            for file in output_files:
-                ds = pydicom.dcmread(file)
-                
-                assert ds.PatientName == "", "PatientName should be empty"
-                assert ds.PatientID == "", "PatientID should be empty"
-                assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
-                assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
-                assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
-                assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
-                assert ds.Modality == "CT", "Modality should be kept"
-    
-    finally:
-        orthanc.stop()
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        output_files = list(output_dir.rglob("*.dcm"))
+        assert len(output_files) >= 9
+
+        for file in output_files:
+            ds = pydicom.dcmread(file)
+
+            assert ds.PatientName == "", "PatientName should be empty"
+            assert ds.PatientID == "", "PatientID should be empty"
+            assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
+            assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
+            assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
+            assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
+            assert ds.Modality == "CT", "Modality should be kept"
 
 
-def test_id_map_audit_log_extraction(tmp_path):
+def test_id_map_audit_log_extraction(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(5):
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"MRN{i:04d}",
-                patient_name=f"Patient{i}^Test",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality="CT"
-            )
-            ds.SeriesNumber = 1
-            ds.InstanceNumber = i + 1
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
 
-        anonymizer_script = """<script>
+    for i in range(5):
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"MRN{i:04d}",
+            patient_name=f"Patient{i}^Test",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality="CT"
+        )
+        ds.SeriesNumber = 1
+        ds.InstanceNumber = i + 1
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name)
+            orthanc.upload_dicom(tmp.name)
+
+    source_ctp = Path(__file__).parent / "ctp"
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
 
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
 
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
 
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
 
-        time.sleep(2)
+    time.sleep(2)
 
-        with CTPPipeline(
-            pipeline_type="imagedeid_pacs",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            anonymizer_script=anonymizer_script,
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
+    with CTPPipeline(
+        pipeline_type="imagedeid_pacs",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        anonymizer_script=anonymizer_script,
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
 
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            audit_log_csv = pipeline.get_audit_log_csv("AuditLog")
-            assert audit_log_csv is not None, "AuditLog CSV should be retrieved"
-            assert len(audit_log_csv.split('\n')) > 1, "AuditLog should have data rows"
-            
-            deid_audit_log_csv = pipeline.get_audit_log_csv("DeidAuditLog")
-            assert deid_audit_log_csv is not None, "DeidAuditLog CSV should be retrieved"
-            assert len(deid_audit_log_csv.split('\n')) > 1, "DeidAuditLog should have data rows"
-            
-            linker_csv = pipeline.get_idmap_csv()
-            assert linker_csv is not None, "IDMap linker CSV should be retrieved"
-            assert len(linker_csv.split('\n')) > 1, "Linker CSV should have data rows"
-            
-            audit_lines = [line for line in audit_log_csv.split('\n') if line.strip()]
-            deid_audit_lines = [line for line in deid_audit_log_csv.split('\n') if line.strip()]
-            linker_lines = [line for line in linker_csv.split('\n') if line.strip()]
-            
-            assert len(audit_lines) >= 2, "AuditLog should have header + data rows"
-            assert len(deid_audit_lines) >= 2, "DeidAuditLog should have header + data rows"
-            assert len(linker_lines) >= 2, "Linker should have header + data rows"
-            
-            assert 'ACC' in audit_log_csv, "Original accession numbers should be in AuditLog"
-    
-    finally:
-        orthanc.stop()
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        audit_log_csv = pipeline.get_audit_log_csv("AuditLog")
+        assert audit_log_csv is not None, "AuditLog CSV should be retrieved"
+        assert len(audit_log_csv.split('\n')) > 1, "AuditLog should have data rows"
+
+        deid_audit_log_csv = pipeline.get_audit_log_csv("DeidAuditLog")
+        assert deid_audit_log_csv is not None, "DeidAuditLog CSV should be retrieved"
+        assert len(deid_audit_log_csv.split('\n')) > 1, "DeidAuditLog should have data rows"
+
+        linker_csv = pipeline.get_idmap_csv()
+        assert linker_csv is not None, "IDMap linker CSV should be retrieved"
+        assert len(linker_csv.split('\n')) > 1, "Linker CSV should have data rows"
+
+        audit_lines = [line for line in audit_log_csv.split('\n') if line.strip()]
+        deid_audit_lines = [line for line in deid_audit_log_csv.split('\n') if line.strip()]
+        linker_lines = [line for line in linker_csv.split('\n') if line.strip()]
+
+        assert len(audit_lines) >= 2, "AuditLog should have header + data rows"
+        assert len(deid_audit_lines) >= 2, "DeidAuditLog should have header + data rows"
+        assert len(linker_lines) >= 2, "Linker should have header + data rows"
+
+        assert 'ACC' in audit_log_csv, "Original accession numbers should be in AuditLog"
 
 
 def test_imagedeid_local_pixel_with_anonymizer_script(tmp_path):
@@ -1502,52 +1454,47 @@ def test_imagedeid_local_pixel_with_anonymizer_script(tmp_path):
             assert ds.Modality == "CT", "Modality should be kept"
 
 
-def test_imagedeid_pacs_pixel_with_anonymizer_script(tmp_path):
+def test_imagedeid_pacs_pixel_with_anonymizer_script(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(10):
-            ds = Fixtures.create_minimal_dicom(
-                patient_id=f"MRN{i:04d}",
-                patient_name=f"Smith^John{i}",
-                accession=f"ACC{i:03d}",
-                study_date="20250101",
-                modality="CT"
-            )
-            ds.InstitutionName = "Test Hospital"
-            ds.ReferringPhysicianName = "Dr. Referring"
-            ds.Manufacturer = "TestManufacturer"
-            ds.ManufacturerModelName = "TestModel"
-            ds.SeriesNumber = (i % 2) + 1
-            ds.InstanceNumber = i + 1
-            ds.SamplesPerPixel = 1
-            ds.PhotometricInterpretation = "MONOCHROME2"
-            ds.Rows = 512
-            ds.Columns = 512
-            ds.BitsAllocated = 16
-            ds.BitsStored = 16
-            ds.HighBit = 15
-            ds.PixelRepresentation = 0
-            ds.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
-            
-            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
-                ds.save_as(tmp.name, write_like_original=False)
-                orthanc.upload_dicom(tmp.name)
-        
-        source_ctp = Path(__file__).parent / "ctp"
-        
-        anonymizer_script = """<script>
+
+    for i in range(10):
+        ds = Fixtures.create_minimal_dicom(
+            patient_id=f"MRN{i:04d}",
+            patient_name=f"Smith^John{i}",
+            accession=f"ACC{i:03d}",
+            study_date="20250101",
+            modality="CT"
+        )
+        ds.InstitutionName = "Test Hospital"
+        ds.ReferringPhysicianName = "Dr. Referring"
+        ds.Manufacturer = "TestManufacturer"
+        ds.ManufacturerModelName = "TestModel"
+        ds.SeriesNumber = (i % 2) + 1
+        ds.InstanceNumber = i + 1
+        ds.SamplesPerPixel = 1
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.Rows = 512
+        ds.Columns = 512
+        ds.BitsAllocated = 16
+        ds.BitsStored = 16
+        ds.HighBit = 15
+        ds.PixelRepresentation = 0
+        ds.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
+
+        with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+            ds.save_as(tmp.name, write_like_original=False)
+            orthanc.upload_dicom(tmp.name)
+
+    source_ctp = Path(__file__).parent / "ctp"
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080080" n="InstitutionName">@remove()</e>
@@ -1556,62 +1503,59 @@ def test_imagedeid_pacs_pixel_with_anonymizer_script(tmp_path):
 <e en="T" t="00081090" n="ManufacturerModelName">@keep()</e>
 <e en="T" t="00080060" n="Modality">@keep()</e>
 </script>"""
-        
-        studies_response = requests.get(f"{orthanc.base_url}/studies")
-        studies = studies_response.json()
-        
-        for study_id in studies:
-            study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
-            study_uid = study_info['MainDicomTags']['StudyInstanceUID']
-            
-            result = get_study(
-                host="localhost",
-                port=orthanc.dicom_port,
-                calling_aet="TEST_AET",
-                called_aet=orthanc.aet,
-                output_dir=str(input_dir),
-                study_uid=study_uid
-            )
-            if not result["success"]:
-                print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
-        
-        time.sleep(2)
-        
-        with CTPPipeline(
-            pipeline_type="imagedeid_pacs_pixel",
-            input_dir=str(input_dir),
-            output_dir=str(output_dir),
-            application_aet="TEST_AET",
-            anonymizer_script=anonymizer_script,
-            source_ctp_dir=str(source_ctp)
-        ) as pipeline:
-            start_time = time.time()
-            timeout = 60
-            
-            while not pipeline.is_complete():
-                if time.time() - start_time > timeout:
-                    raise TimeoutError("Pipeline did not complete")
-                time.sleep(1)
-            
-            output_files = list(output_dir.rglob("*.dcm"))
-            
-            assert pipeline.metrics.files_received >= 9, f"Expected at least 9 files received, got {pipeline.metrics.files_received}"
-            assert pipeline.metrics.files_saved + pipeline.metrics.files_quarantined >= 9, "Expected at least 9 files processed"
-            assert len(output_files) >= 9, f"Expected at least 9 output files, got {len(output_files)}"
-            
-            for file in output_files:
-                ds = pydicom.dcmread(file)
-                
-                assert ds.PatientName == "", "PatientName should be empty"
-                assert ds.PatientID == "", "PatientID should be empty"
-                assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
-                assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
-                assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
-                assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
-                assert ds.Modality == "CT", "Modality should be kept"
-    
-    finally:
-        orthanc.stop()
+
+    studies_response = requests.get(f"{orthanc.base_url}/studies")
+    studies = studies_response.json()
+
+    for study_id in studies:
+        study_info = requests.get(f"{orthanc.base_url}/studies/{study_id}").json()
+        study_uid = study_info['MainDicomTags']['StudyInstanceUID']
+
+        result = get_study(
+            host="localhost",
+            port=orthanc.dicom_port,
+            calling_aet="TEST_AET",
+            called_aet=orthanc.aet,
+            output_dir=str(input_dir),
+            study_uid=study_uid
+        )
+        if not result["success"]:
+            print(f"Warning: Failed to retrieve study {study_uid}: {result['message']}")
+
+    time.sleep(2)
+
+    with CTPPipeline(
+        pipeline_type="imagedeid_pacs_pixel",
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        application_aet="TEST_AET",
+        anonymizer_script=anonymizer_script,
+        source_ctp_dir=str(source_ctp)
+    ) as pipeline:
+        start_time = time.time()
+        timeout = 60
+
+        while not pipeline.is_complete():
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Pipeline did not complete")
+            time.sleep(1)
+
+        output_files = list(output_dir.rglob("*.dcm"))
+
+        assert pipeline.metrics.files_received >= 9, f"Expected at least 9 files received, got {pipeline.metrics.files_received}"
+        assert pipeline.metrics.files_saved + pipeline.metrics.files_quarantined >= 9, "Expected at least 9 files processed"
+        assert len(output_files) >= 9, f"Expected at least 9 output files, got {len(output_files)}"
+
+        for file in output_files:
+            ds = pydicom.dcmread(file)
+
+            assert ds.PatientName == "", "PatientName should be empty"
+            assert ds.PatientID == "", "PatientID should be empty"
+            assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
+            assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
+            assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
+            assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
+            assert ds.Modality == "CT", "Modality should be kept"
 
 
 def test_ctp_server_stall_timeout(tmp_path):

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -21,7 +21,7 @@ from pydicom.uid import (
 from ctp import CTPServer, CTPPipeline, PIPELINE_TEMPLATES
 from dcmtk import get_study
 from module_imagedeid_local import imagedeid_local
-from test_utils import cleanup_docker_containers, Fixtures, OrthancServer
+from test_utils import Fixtures, OrthancServer
 
 
 CT_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.2"
@@ -656,7 +656,7 @@ ptid/P006=P106
         for file in output_files:
             ds = pydicom.dcmread(file)
             
-            assert ds.PatientName == "", f"PatientName should be empty"
+            assert ds.PatientName == "", "PatientName should be empty"
             
             found_patient_ids.add(ds.PatientID)
             found_accessions.add(ds.AccessionNumber)
@@ -747,10 +747,10 @@ def test_imagedeid_local_with_filter(tmp_path):
         for file in output_files:
             ds = pydicom.dcmread(file)
             assert ds.Modality == "CT", f"Only CT files should be in output, found {ds.Modality}"
-            assert ds.PatientName == "", f"PatientName should be anonymized"
+            assert ds.PatientName == "", "PatientName should be anonymized"
         
-        assert pipeline.metrics.files_saved == 3, f"Expected 3 CT files saved"
-        assert pipeline.metrics.files_quarantined == 3, f"Expected 3 MR files quarantined"
+        assert pipeline.metrics.files_saved == 3, "Expected 3 CT files saved"
+        assert pipeline.metrics.files_quarantined == 3, "Expected 3 MR files quarantined"
         
         quarantined_files = list(custom_quarantine_dir.rglob("*.dcm"))
         assert len(quarantined_files) == 3, f"Expected 3 quarantined files in custom directory, got {len(quarantined_files)}"
@@ -1214,9 +1214,9 @@ def test_imagedeid_pacs_with_filter(tmp_path):
                 assert ds.Modality == "CT", f"Only CT files should be in output, found {ds.Modality}"
                 assert ds.PatientName == "", f"PatientName should be anonymized, got '{ds.PatientName}'"
             
-            assert pipeline.metrics.files_saved == 3, f"Expected 3 CT files saved"
-            assert pipeline.metrics.files_quarantined == 3, f"Expected 3 MR files quarantined"
-            assert pipeline.metrics.files_received == 6, f"Expected 6 files received"
+            assert pipeline.metrics.files_saved == 3, "Expected 3 CT files saved"
+            assert pipeline.metrics.files_quarantined == 3, "Expected 3 MR files quarantined"
+            assert pipeline.metrics.files_received == 6, "Expected 6 files received"
     
     finally:
         orthanc.stop()
@@ -1596,7 +1596,7 @@ def test_imagedeid_pacs_pixel_with_anonymizer_script(tmp_path):
             output_files = list(output_dir.rglob("*.dcm"))
             
             assert pipeline.metrics.files_received >= 9, f"Expected at least 9 files received, got {pipeline.metrics.files_received}"
-            assert pipeline.metrics.files_saved + pipeline.metrics.files_quarantined >= 9, f"Expected at least 9 files processed"
+            assert pipeline.metrics.files_saved + pipeline.metrics.files_quarantined >= 9, "Expected at least 9 files processed"
             assert len(output_files) >= 9, f"Expected at least 9 output files, got {len(output_files)}"
             
             for file in output_files:

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -14,6 +14,7 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
     RLELossless,
+    UID,
     generate_uid,
 )
 
@@ -46,12 +47,12 @@ TOTAL_TRANSFER_SYNTAX_FILES = 2 + len(COMPRESSED_FIXTURE_FILES)  # 2 generated +
 
 def create_dicom_with_transfer_syntax(transfer_syntax_uid, suffix=""):
     file_meta = FileMetaDataset()
-    file_meta.MediaStorageSOPClassUID = CT_SOP_CLASS
+    file_meta.MediaStorageSOPClassUID = UID(CT_SOP_CLASS)
     file_meta.MediaStorageSOPInstanceUID = generate_uid()
     file_meta.TransferSyntaxUID = transfer_syntax_uid
     file_meta.ImplementationClassUID = generate_uid()
 
-    ds = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds = FileDataset("", {}, file_meta=file_meta, preamble=b"\0" * 128)
     ds.is_little_endian = True
     ds.is_implicit_VR = transfer_syntax_uid == ImplicitVRLittleEndian
     ds.PatientName = f"Test^{suffix}"
@@ -123,8 +124,8 @@ def create_test_dicoms(input_dir, num_files=10):
         
         ds.file_meta = pydicom.dataset.FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
-        ds.file_meta.MediaStorageSOPClassUID = ds.SOPClassUID
-        ds.file_meta.MediaStorageSOPInstanceUID = ds.SOPInstanceUID
+        ds.file_meta.MediaStorageSOPClassUID = UID(ds.SOPClassUID)
+        ds.file_meta.MediaStorageSOPInstanceUID = UID(ds.SOPInstanceUID)
         ds.is_little_endian = True
         ds.is_implicit_VR = True
         
@@ -354,6 +355,7 @@ def test_pacs_pipeline_force_kill(tmp_path):
 
     try:
         time.sleep(3)
+        assert pipeline1.server is not None and pipeline1.server.process is not None
         assert pipeline1.server.process.poll() is None, "First pipeline should be running"
 
         pipeline2 = CTPPipeline(
@@ -369,12 +371,14 @@ def test_pacs_pipeline_force_kill(tmp_path):
         try:
             time.sleep(3)
             
+            assert pipeline1.server is not None and pipeline1.server.process is not None
             assert pipeline1.server.process.poll() is not None, "First pipeline should be killed"
+            assert pipeline2.server is not None and pipeline2.server.process is not None
             assert pipeline2.server.process.poll() is None, "Second pipeline should be running"
         finally:
             pipeline2.__exit__(None, None, None)
     finally:
-        if pipeline1.server.process and pipeline1.server.process.poll() is None:
+        if pipeline1.server and pipeline1.server.process and pipeline1.server.process.poll() is None:
             pipeline1.__exit__(None, None, None)
 
 
@@ -480,6 +484,7 @@ def test_kills_existing_ctp_instance(tmp_path):
     
     time.sleep(2)
     
+    assert server1.process is not None
     assert server1.process.poll() is None, "Server1 should be running"
     
     response1 = requests.get("http://localhost:50000/status", timeout=2)
@@ -497,8 +502,10 @@ def test_kills_existing_ctp_instance(tmp_path):
         
         time.sleep(2)
         
+        assert server1.process is not None
         assert server1.process.poll() is not None, "Server1 should have been terminated"
-        
+
+        assert server2.process is not None
         assert server2.process.poll() is None, "Server2 should be running"
         
         response2 = requests.get("http://localhost:50000/status", timeout=2)

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -136,65 +136,29 @@ def create_test_dicoms(input_dir, num_files=10):
 def test_ctp_port_selection_local_pipeline(tmp_path):
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
-    
+
     input_dir.mkdir()
     output_dir.mkdir()
-    
+
     source_ctp = Path(__file__).parent / "ctp"
-    
+
     pipeline = CTPPipeline(
         pipeline_type="imagecopy_local",
         output_dir=str(output_dir),
         input_dir=str(input_dir),
         source_ctp_dir=str(source_ctp)
     )
-    assert pipeline.port == 50000, "Should pick port 50000 when available"
-    
-    blocked_sockets = []
-    try:
-        for attempt in range(3):
-            port = 50000 + (attempt * 10)
-            
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(('localhost', port))
-            sock.listen(1)
-            blocked_sockets.append(sock)
-        
-        pipeline = CTPPipeline(
-            source_ctp_dir=str(source_ctp),
-            pipeline_type="imagecopy_local",
-            output_dir=str(output_dir),
-            input_dir=str(input_dir)
-        )
-        assert pipeline.port == 50030, "Should pick port 50030 when 50000, 50010, 50020 are blocked"
-        
-    finally:
-        for sock in blocked_sockets:
-            sock.close()
-    
-    blocked_sockets = []
-    try:
-        for attempt in range(10):
-            port = 50000 + (attempt * 10)
-            
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(('localhost', port))
-            sock.listen(1)
-            blocked_sockets.append(sock)
-        
-        with pytest.raises(RuntimeError, match="Could not find available port after 10 attempts"):
-            CTPPipeline(
-                source_ctp_dir=str(source_ctp),
-                pipeline_type="imagecopy_local",
-                output_dir=str(output_dir),
-                input_dir=str(input_dir)
-            )
-    
-    finally:
-        for sock in blocked_sockets:
-            sock.close()
+    assert isinstance(pipeline.port, int), "Port should be an integer"
+    assert pipeline.port > 0, "Port should be positive"
+
+    pipeline2 = CTPPipeline(
+        pipeline_type="imagecopy_local",
+        output_dir=str(output_dir),
+        input_dir=str(input_dir),
+        source_ctp_dir=str(source_ctp)
+    )
+    assert isinstance(pipeline2.port, int), "Port should be an integer"
+    assert pipeline.port != pipeline2.port, "Two pipelines should have different ports"
 
 
 def test_ctp_port_avoids_dicom_port(tmp_path):
@@ -215,8 +179,7 @@ def test_ctp_port_avoids_dicom_port(tmp_path):
     )
     assert pipeline._dicom_port == 50005, "DICOM port should be set to 50005"
     assert pipeline.port != 50005, "CTP port should not conflict with DICOM port"
-    assert pipeline.port in [50000, 50010, 50020, 50030, 50040, 50050, 50060, 50070, 50080, 50090], \
-        f"CTP port should be one of the standard ports, got {pipeline.port}"
+    assert pipeline.port > 0, "CTP port should be a valid port"
 
 
 def test_parallel_local_pipelines(tmp_path):
@@ -293,7 +256,7 @@ def test_pacs_pipeline_with_custom_dicom_port(tmp_path):
 
     assert pipeline._dicom_port == 11112, "DICOM port should be set to 11112"
     assert pipeline.port != 11112, "CTP port should not equal DICOM port"
-    assert pipeline.port >= 50000, "CTP port should be in expected range"
+    assert pipeline.port > 0, "CTP port should be a valid port"
 
 
 @pytest.mark.skip(reason="No longer applicable: imagedeid_pacs now uses ArchiveImportService (file-based) instead of DicomImportService (network-based) after C-MOVE to C-GET migration")
@@ -408,37 +371,41 @@ def test_archive_import_to_directory_storage(tmp_path):
     
     time.sleep(2)
     
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('localhost', 0))
+        free_port = s.getsockname()[1]
+
     config_xml = PIPELINE_TEMPLATES["imagecopy_local"].format(
         input_dir=str(input_dir.absolute()),
         output_dir=str(output_dir.absolute()),
         tempdir=str(tempdir.absolute()),
-        port=50000
+        port=free_port
     )
-    
+
     config_path = ctp_dir / "config.xml"
     config_path.write_text(config_xml)
-    
+
     server = CTPServer(str(ctp_dir))
-    
+
     try:
         server.start()
-        
+
         start_time = time.time()
         timeout = 60
-        
+
         while not server.is_complete():
             if time.time() - start_time > timeout:
                 raise TimeoutError(f"CTP pipeline did not complete within {timeout} seconds")
             time.sleep(1)
-        
+
         total_files = server.metrics.files_saved + server.metrics.files_quarantined
         assert total_files == 100, f"Expected 100 files, got {total_files}"
-        
+
         assert server.metrics.files_received == 100, f"Expected 100 files received, got {server.metrics.files_received}"
-        
+
         output_files = list(output_dir.rglob("*.dcm"))
         assert len(output_files) == 100, f"Expected 100 output files, found {len(output_files)}"
-    
+
     finally:
         server.stop()
 
@@ -469,48 +436,52 @@ def test_kills_existing_ctp_instance(tmp_path):
     
     time.sleep(2)
     
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('localhost', 0))
+        free_port = s.getsockname()[1]
+
     config_xml = PIPELINE_TEMPLATES["imagecopy_local"].format(
         input_dir=str(input_dir.absolute()),
         output_dir=str(output_dir.absolute()),
         tempdir=str(tempdir.absolute()),
-        port=50000
+        port=free_port
     )
-    
+
     config_path = ctp_dir / "config.xml"
     config_path.write_text(config_xml)
-    
+
     server1 = CTPServer(str(ctp_dir))
     server1.start()
-    
+
     time.sleep(2)
-    
+
     assert server1.process is not None
     assert server1.process.poll() is None, "Server1 should be running"
-    
-    response1 = requests.get("http://localhost:50000/status", timeout=2)
-    assert response1.status_code == 200, "Server1 should be responding on port 50000"
-    
+
+    response1 = requests.get(f"http://localhost:{free_port}/status", timeout=2)
+    assert response1.status_code == 200, f"Server1 should be responding on port {free_port}"
+
     shutil.rmtree(tempdir / "roots", ignore_errors=True)
     shutil.rmtree(tempdir / "quarantine", ignore_errors=True)
     (tempdir / "roots").mkdir()
     (tempdir / "quarantine").mkdir()
-    
+
     server2 = CTPServer(str(ctp_dir))
-    
+
     try:
         server2.start()
-        
+
         time.sleep(2)
-        
+
         assert server1.process is not None
         assert server1.process.poll() is not None, "Server1 should have been terminated"
 
         assert server2.process is not None
         assert server2.process.poll() is None, "Server2 should be running"
-        
-        response2 = requests.get("http://localhost:50000/status", timeout=2)
-        assert response2.status_code == 200, "Server2 should be responding on port 50000"
-    
+
+        response2 = requests.get(f"http://localhost:{free_port}/status", timeout=2)
+        assert response2.status_code == 200, f"Server2 should be responding on port {free_port}"
+
     finally:
         server2.stop()
         if server1.process and server1.process.poll() is None:

--- a/test_ctp.py
+++ b/test_ctp.py
@@ -122,8 +122,8 @@ def create_test_dicoms(input_dir, num_files=10):
         ds.PixelRepresentation = 0
         ds.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
         
-        ds.file_meta = pydicom.dataset.FileMetaDataset()
-        ds.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+        ds.file_meta = FileMetaDataset()
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.file_meta.MediaStorageSOPClassUID = UID(ds.SOPClassUID)
         ds.file_meta.MediaStorageSOPInstanceUID = UID(ds.SOPInstanceUID)
         ds.is_little_endian = True
@@ -918,10 +918,9 @@ def test_imageqr_pipeline(tmp_path):
             ds.SeriesNumber = (i % 2) + 1
             ds.InstanceNumber = i + 1
 
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
 
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -998,10 +997,9 @@ def test_imageqr_with_filter(tmp_path):
             ds.SeriesNumber = 1
             ds.InstanceNumber = i + 1
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -1081,10 +1079,9 @@ def test_imagedeid_pacs_pipeline(tmp_path):
             ds.SeriesNumber = (i % 2) + 1
             ds.InstanceNumber = i + 1
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -1162,10 +1159,9 @@ def test_imagedeid_pacs_with_filter(tmp_path):
             ds.SeriesNumber = 1
             ds.InstanceNumber = i + 1
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -1256,10 +1252,9 @@ def test_imagedeid_pacs_with_anonymizer_script(tmp_path):
             ds.SeriesNumber = (i % 2) + 1
             ds.InstanceNumber = i + 1
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -1353,10 +1348,9 @@ def test_id_map_audit_log_extraction(tmp_path):
             ds.SeriesNumber = 1
             ds.InstanceNumber = i + 1
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
 
@@ -1547,10 +1541,9 @@ def test_imagedeid_pacs_pixel_with_anonymizer_script(tmp_path):
             ds.PixelRepresentation = 0
             ds.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
             
-            temp_file = tempfile.mktemp(suffix=".dcm")
-            ds.save_as(temp_file, write_like_original=False)
-            orthanc.upload_dicom(temp_file)
-            os.remove(temp_file)
+            with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                ds.save_as(tmp.name, write_like_original=False)
+                orthanc.upload_dicom(tmp.name)
         
         source_ctp = Path(__file__).parent / "ctp"
         

--- a/test_dcmtk.py
+++ b/test_dcmtk.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 import pytest
 import time

--- a/test_dcmtk.py
+++ b/test_dcmtk.py
@@ -103,7 +103,8 @@ def test_find_studies_single_result(tmp_path):
             if arg == "-Xs":
                 xml_path = args[0][i + 1]
                 break
-        
+        assert xml_path is not None
+
         with open(xml_path, 'w') as f:
             f.write(FINDSCU_SINGLE_ACCESSION_XML)
         
@@ -134,7 +135,8 @@ def test_find_studies_multiple_results(tmp_path):
             if arg == "-Xs":
                 xml_path = args[0][i + 1]
                 break
-        
+        assert xml_path is not None
+
         with open(xml_path, 'w') as f:
             f.write(FINDSCU_MULTIPLE_PATIENT_DATE_XML)
         
@@ -165,7 +167,8 @@ def test_find_studies_no_results(tmp_path):
             if arg == "-Xs":
                 xml_path = args[0][i + 1]
                 break
-        
+        assert xml_path is not None
+
         with open(xml_path, 'w') as f:
             f.write(FINDSCU_NO_RESULTS_XML)
         
@@ -251,7 +254,8 @@ def test_invalid_xml_response(tmp_path):
             if arg == "-Xs":
                 xml_path = args[0][i + 1]
                 break
-        
+        assert xml_path is not None
+
         with open(xml_path, 'w') as f:
             f.write("<invalid>xml</that><is>broken")
         
@@ -281,10 +285,11 @@ def test_find_studies_retries_on_failure(tmp_path):
             if arg == "-Xs":
                 xml_path = args[0][i + 1]
                 break
-        
+        assert xml_path is not None
+
         if attempt_count["count"] == 1:
             return mock.Mock(returncode=1, stdout="", stderr="Network timeout")
-        
+
         with open(xml_path, 'w') as f:
             f.write(FINDSCU_SINGLE_ACCESSION_XML)
         

--- a/test_module_image_export.py
+++ b/test_module_image_export.py
@@ -36,7 +36,7 @@ def test_image_export_single_file(tmp_path, azurite):
     sas_url = azurite.get_sas_url(container_name)
     project_name = "TestProject"
     
-    result = image_export(
+    image_export(
         input_dir=str(input_dir),
         sas_url=sas_url,
         project_name=project_name,
@@ -78,7 +78,7 @@ def test_image_export_preserves_folder_structure(tmp_path, azurite):
     sas_url = azurite.get_sas_url(container_name)
     project_name = "TestProject"
     
-    result = image_export(
+    image_export(
         input_dir=str(input_dir),
         sas_url=sas_url,
         project_name=project_name,
@@ -168,7 +168,7 @@ def test_image_export_multiple_file_types(tmp_path, azurite):
     sas_url = azurite.get_sas_url(container_name)
     project_name = "TestProject"
     
-    result = image_export(
+    image_export(
         input_dir=str(input_dir),
         sas_url=sas_url,
         project_name=project_name,

--- a/test_module_image_export.py
+++ b/test_module_image_export.py
@@ -5,19 +5,10 @@ import pydicom
 from pydicom.filebase import DicomBytesIO
 
 from module_image_export import image_export
-from test_utils import _create_test_dicom, AzuriteServer
+from test_utils import _create_test_dicom
 
 
 logging.basicConfig(level=logging.INFO)
-
-
-@pytest.fixture(scope="function")
-def azurite():
-    """Fixture to start and stop Azurite for each test"""
-    server = AzuriteServer()
-    server.start()
-    yield server
-    server.stop()
 
 
 def test_image_export_single_file(tmp_path, azurite):

--- a/test_module_image_export.py
+++ b/test_module_image_export.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import pydicom
+from pydicom.filebase import DicomBytesIO
 
 from module_image_export import image_export
 from test_utils import _create_test_dicom, AzuriteServer
@@ -49,7 +50,7 @@ def test_image_export_single_file(tmp_path, azurite):
     assert blobs[0] == f"{project_name}/test001.dcm"
     
     blob_content = azurite.get_blob_content(container_name, blobs[0])
-    downloaded_ds = pydicom.dcmread(pydicom.filebase.DicomBytesIO(blob_content))
+    downloaded_ds = pydicom.dcmread(DicomBytesIO(blob_content))
     assert downloaded_ds.AccessionNumber == "ACC001"
     assert downloaded_ds.PatientID == "MRN001"
 

--- a/test_module_image_export.py
+++ b/test_module_image_export.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from pathlib import Path
 
 import pytest
 import pydicom

--- a/test_module_imagedeid_local.py
+++ b/test_module_imagedeid_local.py
@@ -275,7 +275,7 @@ def test_continuous_audit_log_saving(tmp_path):
     monitor_thread = threading.Thread(target=monitor_files, daemon=True)
     monitor_thread.start()
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -509,7 +509,7 @@ def test_imagedeid_local_with_mapping_file_basic(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@keep()</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -573,7 +573,7 @@ def test_imagedeid_local_with_mapping_file_multiple_tags(tmp_path):
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -643,7 +643,7 @@ def test_imagedeid_local_date_format_conversion(tmp_path):
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -736,7 +736,7 @@ def test_imagedeid_local_fallback_to_simple_action(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@empty()</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -789,7 +789,7 @@ def test_imagedeid_local_complex_function_quarantines(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -840,7 +840,7 @@ def test_imagedeid_local_tag_not_in_script(tmp_path):
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),
@@ -894,7 +894,7 @@ def test_explicit_lookup_table_overrides_mapping_file(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@lookup(this,AccessionNumber,keep)</e>
 </script>"""
     
-    result = imagedeid_local(
+    imagedeid_local(
         input_dir=str(input_dir),
         output_dir=str(output_dir),
         appdata_dir=str(appdata_dir),

--- a/test_module_imagedeid_pacs.py
+++ b/test_module_imagedeid_pacs.py
@@ -17,7 +17,7 @@ from utils import PacsConfiguration, Spreadsheet
 logging.basicConfig(level=logging.INFO)
 
 
-def test_imagedeid_pacs_with_accession_filter(tmp_path):
+def test_imagedeid_pacs_with_accession_filter(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -27,43 +27,38 @@ def test_imagedeid_pacs_with_accession_filter(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i in range(3):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "0.5")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i in range(3):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "0.5")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        for i in range(3, 6):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        for i in range(6, 9):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "MR", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": [f"ACC{i:03d}" for i in range(9)]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    for i in range(3, 6):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
+    
+    for i in range(6, 9):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "MR", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
+    
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": [f"ACC{i:03d}" for i in range(9)]
+    })
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080080" n="InstitutionName">@remove()</e>
@@ -73,101 +68,98 @@ def test_imagedeid_pacs_with_accession_filter(tmp_path):
 <e en="T" t="00080060" n="Modality">@keep()</e>
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
-        
-        filter_script = 'Modality.contains("CT") * SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
-        
-        result = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            filter_script=filter_script,
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
-        
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            
-            assert ds.PatientName == "", "PatientName should be empty"
-            assert ds.PatientID == "", "PatientID should be empty"
-            assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
-            assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
-            assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
-            assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
-            assert ds.Modality == "CT", "Modality should be kept"
-        
-        deid_metadata_path = appdata_dir / "deid_metadata.xlsx"
-        assert deid_metadata_path.exists(), "deid_metadata.xlsx should exist"
-        
-        deid_df = pd.read_excel(deid_metadata_path)
-        assert len(deid_df) == 3, "deid_metadata.xlsx should have 3 rows"
-        
-        if "PatientName" in deid_df.columns:
-            patient_names = deid_df["PatientName"].astype(str)
-            assert all(name in ["", "nan", '=""'] for name in patient_names), "PatientName should be empty"
-        if "PatientID" in deid_df.columns:
-            patient_ids = deid_df["PatientID"].astype(str)
-            assert all(pid in ["", "nan", '=""'] for pid in patient_ids), "PatientID should be empty"
-        
-        for _, row in deid_df.iterrows():
-            for col in row.index:
-                value = str(row[col])
-                assert "Smith" not in value, f"PHI (Smith) found in column {col}"
-                assert "John" not in value, f"PHI (John) found in column {col}"
-        
-        linker_path = appdata_dir / "linker.xlsx"
-        assert linker_path.exists(), "linker.xlsx should exist"
-        
-        linker_df = pd.read_excel(linker_path)
-        assert len(linker_df) > 0, "linker.xlsx should have content"
-        assert "Original AccessionNumber" in linker_df.columns, "Linker should have Original AccessionNumber column"
-        assert "Trial AccessionNumber" in linker_df.columns, "Linker should have Trial AccessionNumber column"
-        
-        original_accessions_in_linker = set()
-        for _, row in linker_df.iterrows():
-            orig_acc = str(row["Original AccessionNumber"])
-            orig_acc = orig_acc.strip().strip('="').strip('(').strip(')').strip('"')
-            if orig_acc and orig_acc != "nan":
-                original_accessions_in_linker.add(orig_acc)
-        
-        expected_accessions = {f"ACC{i:03d}" for i in range(3, 6)}
-        found_accessions = original_accessions_in_linker & expected_accessions
-        assert len(found_accessions) >= 1, f"At least one of the expected accession numbers should be in linker. Found: {original_accessions_in_linker}, Expected: {expected_accessions}"
-        
-        for _, row in linker_df.iterrows():
-            trial_acc = str(row["Trial AccessionNumber"]).strip().strip('="').strip('(').strip(')').strip('"')
-            orig_acc = str(row["Original AccessionNumber"]).strip().strip('="').strip('(').strip(')').strip('"')
-            if trial_acc and orig_acc and trial_acc != "nan" and orig_acc != "nan":
-                assert trial_acc != orig_acc, f"Trial accession should be different from original: {trial_acc} vs {orig_acc}"
-        
-        assert result["num_studies_found"] >= 3
-        assert result["num_images_saved"] == 3
-        
-        quarantine_dir = appdata_dir / "quarantine"
-        assert quarantine_dir.exists(), "Quarantine directory should exist in appdata"
-        
-        quarantined_files = list(quarantine_dir.rglob("*.dcm"))
-        assert len(quarantined_files) == 6, f"Expected 6 quarantined files, found {len(quarantined_files)}"
-        
-        for file in quarantined_files:
-            ds = pydicom.dcmread(file)
-            assert ds.Modality in ["CT", "MR"], "Quarantined file should be either CT or MR"
-            if ds.Modality == "CT":
-                slice_thickness = float(ds.SliceThickness)
-                assert slice_thickness <= 1.0 or slice_thickness >= 5.0, f"Quarantined CT should have slice thickness <=1 or >=5, got {slice_thickness}"
-            else:
-                assert ds.Modality == "MR", "Non-CT quarantined file should be MR"
     
-    finally:
-        orthanc.stop()
+    filter_script = 'Modality.contains("CT") * SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
+    
+    result = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        filter_script=filter_script,
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
+    
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        
+        assert ds.PatientName == "", "PatientName should be empty"
+        assert ds.PatientID == "", "PatientID should be empty"
+        assert not hasattr(ds, 'InstitutionName') or ds.InstitutionName == "", "InstitutionName should be removed"
+        assert not hasattr(ds, 'ReferringPhysicianName') or ds.ReferringPhysicianName == "", "ReferringPhysicianName should be removed"
+        assert ds.Manufacturer == "TestManufacturer", "Manufacturer should be kept"
+        assert ds.ManufacturerModelName == "TestModel", "ManufacturerModelName should be kept"
+        assert ds.Modality == "CT", "Modality should be kept"
+    
+    deid_metadata_path = appdata_dir / "deid_metadata.xlsx"
+    assert deid_metadata_path.exists(), "deid_metadata.xlsx should exist"
+    
+    deid_df = pd.read_excel(deid_metadata_path)
+    assert len(deid_df) == 3, "deid_metadata.xlsx should have 3 rows"
+    
+    if "PatientName" in deid_df.columns:
+        patient_names = deid_df["PatientName"].astype(str)
+        assert all(name in ["", "nan", '=""'] for name in patient_names), "PatientName should be empty"
+    if "PatientID" in deid_df.columns:
+        patient_ids = deid_df["PatientID"].astype(str)
+        assert all(pid in ["", "nan", '=""'] for pid in patient_ids), "PatientID should be empty"
+    
+    for _, row in deid_df.iterrows():
+        for col in row.index:
+            value = str(row[col])
+            assert "Smith" not in value, f"PHI (Smith) found in column {col}"
+            assert "John" not in value, f"PHI (John) found in column {col}"
+    
+    linker_path = appdata_dir / "linker.xlsx"
+    assert linker_path.exists(), "linker.xlsx should exist"
+    
+    linker_df = pd.read_excel(linker_path)
+    assert len(linker_df) > 0, "linker.xlsx should have content"
+    assert "Original AccessionNumber" in linker_df.columns, "Linker should have Original AccessionNumber column"
+    assert "Trial AccessionNumber" in linker_df.columns, "Linker should have Trial AccessionNumber column"
+    
+    original_accessions_in_linker = set()
+    for _, row in linker_df.iterrows():
+        orig_acc = str(row["Original AccessionNumber"])
+        orig_acc = orig_acc.strip().strip('="').strip('(').strip(')').strip('"')
+        if orig_acc and orig_acc != "nan":
+            original_accessions_in_linker.add(orig_acc)
+    
+    expected_accessions = {f"ACC{i:03d}" for i in range(3, 6)}
+    found_accessions = original_accessions_in_linker & expected_accessions
+    assert len(found_accessions) >= 1, f"At least one of the expected accession numbers should be in linker. Found: {original_accessions_in_linker}, Expected: {expected_accessions}"
+    
+    for _, row in linker_df.iterrows():
+        trial_acc = str(row["Trial AccessionNumber"]).strip().strip('="').strip('(').strip(')').strip('"')
+        orig_acc = str(row["Original AccessionNumber"]).strip().strip('="').strip('(').strip(')').strip('"')
+        if trial_acc and orig_acc and trial_acc != "nan" and orig_acc != "nan":
+            assert trial_acc != orig_acc, f"Trial accession should be different from original: {trial_acc} vs {orig_acc}"
+    
+    assert result["num_studies_found"] >= 3
+    assert result["num_images_saved"] == 3
+    
+    quarantine_dir = appdata_dir / "quarantine"
+    assert quarantine_dir.exists(), "Quarantine directory should exist in appdata"
+    
+    quarantined_files = list(quarantine_dir.rglob("*.dcm"))
+    assert len(quarantined_files) == 6, f"Expected 6 quarantined files, found {len(quarantined_files)}"
+    
+    for file in quarantined_files:
+        ds = pydicom.dcmread(file)
+        assert ds.Modality in ["CT", "MR"], "Quarantined file should be either CT or MR"
+        if ds.Modality == "CT":
+            slice_thickness = float(ds.SliceThickness)
+            assert slice_thickness <= 1.0 or slice_thickness >= 5.0, f"Quarantined CT should have slice thickness <=1 or >=5, got {slice_thickness}"
+        else:
+            assert ds.Modality == "MR", "Non-CT quarantined file should be MR"
+    
 
-
-def test_continuous_audit_log_saving(tmp_path):
+def test_continuous_audit_log_saving(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -177,79 +169,71 @@ def test_continuous_audit_log_saving(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i in range(5):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i in range(5):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(5)]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        pacs_config = PacsConfiguration(host="localhost", port=orthanc.dicom_port, aet=orthanc.aet)
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(5)]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    pacs_config = PacsConfiguration(host="localhost", port=orthanc.dicom_port, aet=orthanc.aet)
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
-        
-        import threading
-        file_write_times = {}
-        lock = threading.Lock()
-        stop_monitoring = threading.Event()
-        
-        def monitor_files():
-            while not stop_monitoring.is_set():
-                for filename in ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]:
-                    filepath = appdata_dir / filename
-                    if filepath.exists():
-                        mtime = os.path.getmtime(filepath)
-                        with lock:
-                            if filename not in file_write_times:
-                                file_write_times[filename] = []
-                            if not file_write_times[filename] or mtime != file_write_times[filename][-1]:
-                                file_write_times[filename].append(mtime)
-                time.sleep(1)
-        
-        monitor_thread = threading.Thread(target=monitor_files, daemon=True)
-        monitor_thread.start()
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        stop_monitoring.set()
-        monitor_thread.join(timeout=2)
-        
-        with lock:
-            for filename in ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]:
-                write_count = len(file_write_times.get(filename, []))
-                assert write_count >= 2, f"{filename} should have been written multiple times (found {write_count} writes), indicating continuous saving"
-        
-        assert (appdata_dir / "metadata.xlsx").exists()
-        assert (appdata_dir / "deid_metadata.xlsx").exists()
-        assert (appdata_dir / "linker.xlsx").exists()
     
-    finally:
-        orthanc.stop()
+    import threading
+    file_write_times = {}
+    lock = threading.Lock()
+    stop_monitoring = threading.Event()
+    
+    def monitor_files():
+        while not stop_monitoring.is_set():
+            for filename in ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]:
+                filepath = appdata_dir / filename
+                if filepath.exists():
+                    mtime = os.path.getmtime(filepath)
+                    with lock:
+                        if filename not in file_write_times:
+                            file_write_times[filename] = []
+                        if not file_write_times[filename] or mtime != file_write_times[filename][-1]:
+                            file_write_times[filename].append(mtime)
+            time.sleep(1)
+    
+    monitor_thread = threading.Thread(target=monitor_files, daemon=True)
+    monitor_thread.start()
+    
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+    
+    stop_monitoring.set()
+    monitor_thread.join(timeout=2)
+    
+    with lock:
+        for filename in ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]:
+            write_count = len(file_write_times.get(filename, []))
+            assert write_count >= 2, f"{filename} should have been written multiple times (found {write_count} writes), indicating continuous saving"
+    
+    assert (appdata_dir / "metadata.xlsx").exists()
+    assert (appdata_dir / "deid_metadata.xlsx").exists()
+    assert (appdata_dir / "linker.xlsx").exists()
+    
 
-
-def test_imagedeid_failures_reported(tmp_path):
+def test_imagedeid_failures_reported(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -291,7 +275,7 @@ def test_imagedeid_failures_reported(tmp_path):
     assert result["num_images_saved"] == 0, "No images should be saved"
 
 
-def test_imagedeid_filter_script_generation(tmp_path):
+def test_imagedeid_filter_script_generation(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -447,7 +431,7 @@ def test_imagedeid_multiple_pacs(tmp_path):
         orthanc2.stop()
 
 
-def test_imagedeid_pacs_mrn_study_date_fallback(tmp_path):
+def test_imagedeid_pacs_mrn_study_date_fallback(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -457,92 +441,84 @@ def test_imagedeid_pacs_mrn_study_date_fallback(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds1, orthanc)
     
-    try:
-        ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        ds2 = _create_test_dicom("", "MRN002", "Patient2", "CT", "3.0")
-        ds2.InstanceNumber = 2
-        _upload_dicom_to_orthanc(ds2, orthanc)
-        
-        ds3 = _create_test_dicom("", "MRN003", "Patient3", "CT", "3.0")
-        ds3.InstanceNumber = 3
-        _upload_dicom_to_orthanc(ds3, orthanc)
-        
-        time.sleep(2)
-        
-        query_file_valid = appdata_dir / "query_valid.xlsx"
-        query_data_valid = {
-            "AccessionNumber": ["ACC001", None, None],
-            "PatientID": ["MRN001", "MRN002", "MRN003"],
-            "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
-        }
-        query_df_valid = pd.DataFrame(query_data_valid)
-        query_df_valid.to_excel(query_file_valid, index=False)
-        
-        query_spreadsheet_valid = Spreadsheet.from_file(
-            str(query_file_valid), 
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        result = imagedeid_pacs(
+    ds2 = _create_test_dicom("", "MRN002", "Patient2", "CT", "3.0")
+    ds2.InstanceNumber = 2
+    _upload_dicom_to_orthanc(ds2, orthanc)
+    
+    ds3 = _create_test_dicom("", "MRN003", "Patient3", "CT", "3.0")
+    ds3.InstanceNumber = 3
+    _upload_dicom_to_orthanc(ds3, orthanc)
+    
+    time.sleep(2)
+    
+    query_file_valid = appdata_dir / "query_valid.xlsx"
+    query_data_valid = {
+        "AccessionNumber": ["ACC001", None, None],
+        "PatientID": ["MRN001", "MRN002", "MRN003"],
+        "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
+    }
+    query_df_valid = pd.DataFrame(query_data_valid)
+    query_df_valid.to_excel(query_file_valid, index=False)
+    
+    query_spreadsheet_valid = Spreadsheet.from_file(
+        str(query_file_valid), 
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    result = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet_valid,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        apply_default_filter_script=False
+    )
+    
+    assert result["num_studies_found"] == 3, f"Should find 3 studies, found {result['num_studies_found']}"
+    assert result["num_images_saved"] == 3, f"Should save 3 images, saved {result['num_images_saved']}"
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
+    
+    query_file_invalid = appdata_dir / "query_invalid.xlsx"
+    query_data_invalid = {
+        "AccessionNumber": ["ACC001", None, None, None],
+        "PatientID": ["MRN001", "MRN002", "MRN003", "MRN004"],
+        "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), "invalid-date"]
+    }
+    query_df_invalid = pd.DataFrame(query_data_invalid)
+    query_df_invalid.to_excel(query_file_invalid, index=False)
+    
+    query_spreadsheet_invalid = Spreadsheet.from_file(
+        str(query_file_invalid), 
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
+    
+    with pytest.raises(ValueError, match="StudyDate must be in Excel date format"):
+        imagedeid_pacs(
             pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet_valid,
+            query_spreadsheet=query_spreadsheet_invalid,
             application_aet="TEST_AET",
             output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            apply_default_filter_script=False
+            appdata_dir=str(appdata_dir)
         )
-        
-        assert result["num_studies_found"] == 3, f"Should find 3 studies, found {result['num_studies_found']}"
-        assert result["num_images_saved"] == 3, f"Should save 3 images, saved {result['num_images_saved']}"
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
-        
-        query_file_invalid = appdata_dir / "query_invalid.xlsx"
-        query_data_invalid = {
-            "AccessionNumber": ["ACC001", None, None, None],
-            "PatientID": ["MRN001", "MRN002", "MRN003", "MRN004"],
-            "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), "invalid-date"]
-        }
-        query_df_invalid = pd.DataFrame(query_data_invalid)
-        query_df_invalid.to_excel(query_file_invalid, index=False)
-        
-        query_spreadsheet_invalid = Spreadsheet.from_file(
-            str(query_file_invalid), 
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
-        
-        with pytest.raises(ValueError, match="StudyDate must be in Excel date format"):
-            imagedeid_pacs(
-                pacs_list=[pacs_config],
-                query_spreadsheet=query_spreadsheet_invalid,
-                application_aet="TEST_AET",
-                output_dir=str(output_dir),
-                appdata_dir=str(appdata_dir)
-            )
     
-    finally:
-        orthanc.stop()
 
-
-def test_imagedeid_pacs_date_window(tmp_path):
+def test_imagedeid_pacs_date_window(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -552,138 +528,130 @@ def test_imagedeid_pacs_date_window(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds1 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250101",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    ds1.InstitutionName = "Test Hospital"
+    ds1.Manufacturer = "TestManufacturer"
+    ds1.ManufacturerModelName = "TestModel"
+    ds1.SeriesNumber = 1
+    ds1.InstanceNumber = 1
+    ds1.SamplesPerPixel = 1
+    ds1.PhotometricInterpretation = "MONOCHROME2"
+    ds1.Rows = 64
+    ds1.Columns = 64
+    ds1.BitsAllocated = 16
+    ds1.BitsStored = 16
+    ds1.HighBit = 15
+    ds1.PixelRepresentation = 0
+    ds1.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(ds1, orthanc)
     
-    try:
-        ds1 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250101",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        ds1.InstitutionName = "Test Hospital"
-        ds1.Manufacturer = "TestManufacturer"
-        ds1.ManufacturerModelName = "TestModel"
-        ds1.SeriesNumber = 1
-        ds1.InstanceNumber = 1
-        ds1.SamplesPerPixel = 1
-        ds1.PhotometricInterpretation = "MONOCHROME2"
-        ds1.Rows = 64
-        ds1.Columns = 64
-        ds1.BitsAllocated = 16
-        ds1.BitsStored = 16
-        ds1.HighBit = 15
-        ds1.PixelRepresentation = 0
-        ds1.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        ds2 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250103",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        ds2.InstitutionName = "Test Hospital"
-        ds2.Manufacturer = "TestManufacturer"
-        ds2.ManufacturerModelName = "TestModel"
-        ds2.SeriesNumber = 1
-        ds2.InstanceNumber = 2
-        ds2.SamplesPerPixel = 1
-        ds2.PhotometricInterpretation = "MONOCHROME2"
-        ds2.Rows = 64
-        ds2.Columns = 64
-        ds2.BitsAllocated = 16
-        ds2.BitsStored = 16
-        ds2.HighBit = 15
-        ds2.PixelRepresentation = 0
-        ds2.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(ds2, orthanc)
-        
-        ds3 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250110",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        ds3.InstitutionName = "Test Hospital"
-        ds3.Manufacturer = "TestManufacturer"
-        ds3.ManufacturerModelName = "TestModel"
-        ds3.SeriesNumber = 1
-        ds3.InstanceNumber = 3
-        ds3.SamplesPerPixel = 1
-        ds3.PhotometricInterpretation = "MONOCHROME2"
-        ds3.Rows = 64
-        ds3.Columns = 64
-        ds3.BitsAllocated = 16
-        ds3.BitsStored = 16
-        ds3.HighBit = 15
-        ds3.PixelRepresentation = 0
-        ds3.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(ds3, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": [None],
-            "PatientID": ["MRN001"],
-            "StudyDate": [pd.Timestamp("2025-01-03")]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    ds2 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250103",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    ds2.InstitutionName = "Test Hospital"
+    ds2.Manufacturer = "TestManufacturer"
+    ds2.ManufacturerModelName = "TestModel"
+    ds2.SeriesNumber = 1
+    ds2.InstanceNumber = 2
+    ds2.SamplesPerPixel = 1
+    ds2.PhotometricInterpretation = "MONOCHROME2"
+    ds2.Rows = 64
+    ds2.Columns = 64
+    ds2.BitsAllocated = 16
+    ds2.BitsStored = 16
+    ds2.HighBit = 15
+    ds2.PixelRepresentation = 0
+    ds2.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(ds2, orthanc)
+    
+    ds3 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250110",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    ds3.InstitutionName = "Test Hospital"
+    ds3.Manufacturer = "TestManufacturer"
+    ds3.ManufacturerModelName = "TestModel"
+    ds3.SeriesNumber = 1
+    ds3.InstanceNumber = 3
+    ds3.SamplesPerPixel = 1
+    ds3.PhotometricInterpretation = "MONOCHROME2"
+    ds3.Rows = 64
+    ds3.Columns = 64
+    ds3.BitsAllocated = 16
+    ds3.BitsStored = 16
+    ds3.HighBit = 15
+    ds3.PixelRepresentation = 0
+    ds3.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(ds3, orthanc)
+    
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": [None],
+        "PatientID": ["MRN001"],
+        "StudyDate": [pd.Timestamp("2025-01-03")]
+    })
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
-        
-        result = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            date_window_days=2,
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        
-        study_dates_found = set()
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            study_dates_found.add(ds.StudyDate)
-        
-        assert result["num_studies_found"] >= 2, f"Should find at least 2 studies within 2-day window, found {result['num_studies_found']}"
-        assert result["num_images_saved"] >= 2, f"Should save at least 2 images, saved {result['num_images_saved']}"
-        assert "20250101" in study_dates_found and "20250103" in study_dates_found, f"Should find both studies within 2-day window. Found dates: {study_dates_found}"
-        assert "20250110" not in study_dates_found, f"Should not find study outside window. Found dates: {study_dates_found}"
     
-    finally:
-        orthanc.stop()
+    result = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        date_window_days=2,
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    
+    study_dates_found = set()
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        study_dates_found.add(ds.StudyDate)
+    
+    assert result["num_studies_found"] >= 2, f"Should find at least 2 studies within 2-day window, found {result['num_studies_found']}"
+    assert result["num_images_saved"] >= 2, f"Should save at least 2 images, saved {result['num_images_saved']}"
+    assert "20250101" in study_dates_found and "20250103" in study_dates_found, f"Should find both studies within 2-day window. Found dates: {study_dates_found}"
+    assert "20250110" not in study_dates_found, f"Should not find study outside window. Found dates: {study_dates_found}"
+    
 
-
-def test_imagedeid_pacs_deid_pixels_parameter(tmp_path):
+def test_imagedeid_pacs_deid_pixels_parameter(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -693,56 +661,48 @@ def test_imagedeid_pacs_deid_pixels_parameter(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        result = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            deid_pixels=True,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 1, f"Should find 1 study, found {result['num_studies_found']}"
-        assert result["num_images_saved"] == 1, f"Should save 1 image, saved {result['num_images_saved']}"
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 1, f"Expected 1 .dcm file, found {len(output_files)}"
-        
-        linker_path = appdata_dir / "linker.xlsx"
-        assert linker_path.exists(), "linker.xlsx should exist"
-        
-        deid_metadata_path = appdata_dir / "deid_metadata.xlsx"
-        assert deid_metadata_path.exists(), "deid_metadata.xlsx should exist"
+    time.sleep(2)
     
-    finally:
-        orthanc.stop()
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    result = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        deid_pixels=True,
+        apply_default_filter_script=False
+    )
+    
+    assert result["num_studies_found"] == 1, f"Should find 1 study, found {result['num_studies_found']}"
+    assert result["num_images_saved"] == 1, f"Should save 1 image, saved {result['num_images_saved']}"
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 1, f"Expected 1 .dcm file, found {len(output_files)}"
+    
+    linker_path = appdata_dir / "linker.xlsx"
+    assert linker_path.exists(), "linker.xlsx should exist"
+    
+    deid_metadata_path = appdata_dir / "deid_metadata.xlsx"
+    assert deid_metadata_path.exists(), "deid_metadata.xlsx should exist"
+    
 
-
-def test_imagedeid_pacs_apply_default_filter_script(tmp_path):
+def test_imagedeid_pacs_apply_default_filter_script(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -752,125 +712,117 @@ def test_imagedeid_pacs_apply_default_filter_script(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds1 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="ACC001",
-            study_date="20250101",
-            modality="CT"
-        )
-        ds1.Manufacturer = "UNKNOWN VENDOR"
-        ds1.ImageType = ["DERIVED", "SECONDARY"]
-        ds1.Rows = 512
-        ds1.Columns = 512
-        ds1.SamplesPerPixel = 1
-        ds1.PhotometricInterpretation = "MONOCHROME2"
-        ds1.BitsAllocated = 16
-        ds1.BitsStored = 16
-        ds1.HighBit = 15
-        ds1.PixelRepresentation = 0
-        ds1.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(ds1, orthanc)
+    ds1 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="ACC001",
+        study_date="20250101",
+        modality="CT"
+    )
+    ds1.Manufacturer = "UNKNOWN VENDOR"
+    ds1.ImageType = ["DERIVED", "SECONDARY"]
+    ds1.Rows = 512
+    ds1.Columns = 512
+    ds1.SamplesPerPixel = 1
+    ds1.PhotometricInterpretation = "MONOCHROME2"
+    ds1.BitsAllocated = 16
+    ds1.BitsStored = 16
+    ds1.HighBit = 15
+    ds1.PixelRepresentation = 0
+    ds1.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(ds1, orthanc)
 
-        ds2 = Fixtures.create_minimal_dicom(
-            patient_id="MRN002",
-            patient_name="Patient2",
-            accession="ACC002",
-            study_date="20250101",
-            modality="CT"
-        )
-        ds2.Manufacturer = "GE MEDICAL SYSTEMS"
-        ds2.ManufacturerModelName = "REVOLUTION CT"
-        ds2.SoftwareVersions = "REVO_CT_22BC.50"
-        ds2.ImageType = ["ORIGINAL", "PRIMARY"]
-        ds2.Rows = 512
-        ds2.Columns = 512
-        ds2.SamplesPerPixel = 1
-        ds2.PhotometricInterpretation = "MONOCHROME2"
-        ds2.BitsAllocated = 16
-        ds2.BitsStored = 16
-        ds2.HighBit = 15
-        ds2.PixelRepresentation = 0
-        ds2.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(ds2, orthanc)
+    ds2 = Fixtures.create_minimal_dicom(
+        patient_id="MRN002",
+        patient_name="Patient2",
+        accession="ACC002",
+        study_date="20250101",
+        modality="CT"
+    )
+    ds2.Manufacturer = "GE MEDICAL SYSTEMS"
+    ds2.ManufacturerModelName = "REVOLUTION CT"
+    ds2.SoftwareVersions = "REVO_CT_22BC.50"
+    ds2.ImageType = ["ORIGINAL", "PRIMARY"]
+    ds2.Rows = 512
+    ds2.Columns = 512
+    ds2.SamplesPerPixel = 1
+    ds2.PhotometricInterpretation = "MONOCHROME2"
+    ds2.BitsAllocated = 16
+    ds2.BitsStored = 16
+    ds2.HighBit = 15
+    ds2.PixelRepresentation = 0
+    ds2.PixelData = np.random.randint(0, 4096, (512, 512), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(ds2, orthanc)
 
-        time.sleep(2)
+    time.sleep(2)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
 
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        anonymizer_script = """<script>
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
 
-        result_without_filter = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False,
-        )
+    result_without_filter = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False,
+    )
 
-        assert result_without_filter["num_images_saved"] == 2, "Without default filter, both images should be saved"
-        assert result_without_filter["num_images_quarantined"] == 0, "Without default filter, no images should be quarantined"
+    assert result_without_filter["num_images_saved"] == 2, "Without default filter, both images should be saved"
+    assert result_without_filter["num_images_quarantined"] == 0, "Without default filter, no images should be quarantined"
 
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 2, "Both DICOM files should be in output"
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 2, "Both DICOM files should be in output"
 
-        for file in output_dir.rglob("*.dcm"):
+    for file in output_dir.rglob("*.dcm"):
+        file.unlink()
+    quarantine_dir = appdata_dir / "quarantine"
+    if quarantine_dir.exists():
+        for file in quarantine_dir.rglob("*.dcm"):
             file.unlink()
-        quarantine_dir = appdata_dir / "quarantine"
-        if quarantine_dir.exists():
-            for file in quarantine_dir.rglob("*.dcm"):
-                file.unlink()
 
-        result_with_filter = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=True
-        )
+    result_with_filter = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=True
+    )
 
-        assert result_with_filter["num_images_saved"] == 1, "With default filter, only primary CT should be saved"
-        assert result_with_filter["num_images_quarantined"] == 1, "With default filter, derived CT should be quarantined"
+    assert result_with_filter["num_images_saved"] == 1, "With default filter, only primary CT should be saved"
+    assert result_with_filter["num_images_quarantined"] == 1, "With default filter, derived CT should be quarantined"
 
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 1, "Only one DICOM file should be in output"
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 1, "Only one DICOM file should be in output"
 
-        output_ds = pydicom.dcmread(output_files[0])
-        assert "ORIGINAL" in output_ds.ImageType, "Output file should be the primary CT"
+    output_ds = pydicom.dcmread(output_files[0])
+    assert "ORIGINAL" in output_ds.ImageType, "Output file should be the primary CT"
 
-        quarantine_files = list(quarantine_dir.rglob("*.dcm"))
-        assert len(quarantine_files) == 1, "One DICOM file should be quarantined"
+    quarantine_files = list(quarantine_dir.rglob("*.dcm"))
+    assert len(quarantine_files) == 1, "One DICOM file should be quarantined"
 
-        quarantine_ds = pydicom.dcmread(quarantine_files[0])
-        assert "DERIVED" in quarantine_ds.ImageType, "Quarantined file should be the derived CT"
+    quarantine_ds = pydicom.dcmread(quarantine_files[0])
+    assert "DERIVED" in quarantine_ds.ImageType, "Quarantined file should be the derived CT"
     
-    finally:
-        orthanc.stop()
 
-
-def test_imagedeid_pacs_with_mapping_file_basic(tmp_path):
+def test_imagedeid_pacs_with_mapping_file_basic(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -887,64 +839,56 @@ def test_imagedeid_pacs_with_mapping_file_basic(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, acc in enumerate(["ACC001", "ACC002", "ACC003"]):
+        ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, acc in enumerate(["ACC001", "ACC002", "ACC003"]):
-            ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@keep()</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
-        
-        accession_numbers = []
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            accession_numbers.append(ds.AccessionNumber)
-        
-        assert "MAPPED001" in accession_numbers, "ACC001 should be mapped to MAPPED001"
-        assert "MAPPED002" in accession_numbers, "ACC002 should be mapped to MAPPED002"
-        assert "ACC003" in accession_numbers, "ACC003 should be kept (fallback to @keep())"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
+    
+    accession_numbers = []
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        accession_numbers.append(ds.AccessionNumber)
+    
+    assert "MAPPED001" in accession_numbers, "ACC001 should be mapped to MAPPED001"
+    assert "MAPPED002" in accession_numbers, "ACC002 should be mapped to MAPPED002"
+    assert "ACC003" in accession_numbers, "ACC003 should be kept (fallback to @keep())"
+    
 
-
-def test_imagedeid_pacs_with_mapping_file_multiple_tags(tmp_path):
+def test_imagedeid_pacs_with_mapping_file_multiple_tags(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -965,86 +909,78 @@ def test_imagedeid_pacs_with_mapping_file_multiple_tags(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, (acc, mrn, study_date) in enumerate([
+        ("ACC001", "MRN0000", "20230115"),
+        ("ACC002", "MRN0001", "20230220"),
+        ("ACC999", "MRN0999", "20231231")
+    ]):
+        ds = _create_test_dicom(acc, mrn, f"Patient{i}", "CT", "3.0")
+        ds.StudyDate = study_date
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, (acc, mrn, study_date) in enumerate([
-            ("ACC001", "MRN0000", "20230115"),
-            ("ACC002", "MRN0001", "20230220"),
-            ("ACC999", "MRN0999", "20231231")
-        ]):
-            ds = _create_test_dicom(acc, mrn, f"Patient{i}", "CT", "3.0")
-            ds.StudyDate = study_date
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC999"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC999"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@keep()</e>
 <e en="T" t="00080050" n="AccessionNumber">@empty()</e>
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
-        
-        mapped_files = []
-        unmapped_file = None
-        
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            if ds.AccessionNumber in ["NEWACC001", "NEWACC002"]:
-                mapped_files.append(ds)
-            else:
-                unmapped_file = ds
-        
-        assert len(mapped_files) == 2, "Should have 2 mapped files"
-        assert unmapped_file is not None, "Should have 1 unmapped file"
-        
-        for ds in mapped_files:
-            if ds.AccessionNumber == "NEWACC001":
-                assert ds.PatientID == "NEWMRN0000", "ACC001 PatientID should be mapped"
-                assert ds.StudyDate == "20240615", "ACC001 StudyDate should be mapped"
-            elif ds.AccessionNumber == "NEWACC002":
-                assert ds.PatientID == "NEWMRN0001", "ACC002 PatientID should be mapped"
-                assert ds.StudyDate == "20240720", "ACC002 StudyDate should be mapped"
-        
-        assert unmapped_file.AccessionNumber == "", "ACC999 should be empty (fallback to @empty())"
-        assert unmapped_file.PatientID == "MRN0999", "MRN0999 should be kept (fallback to @keep())"
-        assert unmapped_file.StudyDate == "20231231", "Unmapped study date should be kept (fallback to @keep())"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
+    
+    mapped_files = []
+    unmapped_file = None
+    
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        if ds.AccessionNumber in ["NEWACC001", "NEWACC002"]:
+            mapped_files.append(ds)
+        else:
+            unmapped_file = ds
+    
+    assert len(mapped_files) == 2, "Should have 2 mapped files"
+    assert unmapped_file is not None, "Should have 1 unmapped file"
+    
+    for ds in mapped_files:
+        if ds.AccessionNumber == "NEWACC001":
+            assert ds.PatientID == "NEWMRN0000", "ACC001 PatientID should be mapped"
+            assert ds.StudyDate == "20240615", "ACC001 StudyDate should be mapped"
+        elif ds.AccessionNumber == "NEWACC002":
+            assert ds.PatientID == "NEWMRN0001", "ACC002 PatientID should be mapped"
+            assert ds.StudyDate == "20240720", "ACC002 StudyDate should be mapped"
+    
+    assert unmapped_file.AccessionNumber == "", "ACC999 should be empty (fallback to @empty())"
+    assert unmapped_file.PatientID == "MRN0999", "MRN0999 should be kept (fallback to @keep())"
+    assert unmapped_file.StudyDate == "20231231", "Unmapped study date should be kept (fallback to @keep())"
+    
 
-
-def test_imagedeid_pacs_date_format_conversion_with_mapping(tmp_path):
+def test_imagedeid_pacs_date_format_conversion_with_mapping(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1061,65 +997,57 @@ def test_imagedeid_pacs_date_format_conversion_with_mapping(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, study_date in enumerate(["20230115", "20231231"]):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.StudyDate = study_date
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, study_date in enumerate(["20230115", "20231231"]):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.StudyDate = study_date
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC000", "ACC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC000", "ACC001"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 2, f"Expected 2 output files, got {len(output_files)}"
-        
-        study_dates = set()
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            study_dates.add(ds.StudyDate)
-        
-        assert "20240320" in study_dates, "20230115 should be mapped to 20240320"
-        assert "20241105" in study_dates, "20231231 should be mapped to 20241105"
-        assert "20230115" not in study_dates, "Original date 20230115 should not appear"
-        assert "20231231" not in study_dates, "Original date 20231231 should not appear"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 2, f"Expected 2 output files, got {len(output_files)}"
+    
+    study_dates = set()
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        study_dates.add(ds.StudyDate)
+    
+    assert "20240320" in study_dates, "20230115 should be mapped to 20240320"
+    assert "20241105" in study_dates, "20231231 should be mapped to 20241105"
+    assert "20230115" not in study_dates, "Original date 20230115 should not appear"
+    assert "20231231" not in study_dates, "Original date 20231231 should not appear"
+    
 
-
-def test_imagedeid_pacs_fallback_to_simple_action(tmp_path):
+def test_imagedeid_pacs_fallback_to_simple_action(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1138,64 +1066,56 @@ def test_imagedeid_pacs_fallback_to_simple_action(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, (acc, mrn) in enumerate([("ACC001", "MRN0000"), ("ACC002", "MRN0001"), ("ACC003", "MRN0002")]):
+        ds = _create_test_dicom(acc, mrn, f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, (acc, mrn) in enumerate([("ACC001", "MRN0000"), ("ACC002", "MRN0001"), ("ACC003", "MRN0002")]):
-            ds = _create_test_dicom(acc, mrn, f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@keep()</e>
 <e en="T" t="00080050" n="AccessionNumber">@empty()</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
-        
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            
-            if ds.AccessionNumber == "MAPPED001":
-                assert ds.PatientID == "NEWMRN0000", "Mapped file should have mapped PatientID"
-            else:
-                assert ds.AccessionNumber == "", "Unmapped accession should be empty (fallback to @empty())"
-                assert ds.PatientID in ["MRN0001", "MRN0002"], "Unmapped PatientID should be kept (fallback to @keep())"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
+    
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        
+        if ds.AccessionNumber == "MAPPED001":
+            assert ds.PatientID == "NEWMRN0000", "Mapped file should have mapped PatientID"
+        else:
+            assert ds.AccessionNumber == "", "Unmapped accession should be empty (fallback to @empty())"
+            assert ds.PatientID in ["MRN0001", "MRN0002"], "Unmapped PatientID should be kept (fallback to @keep())"
+    
 
-
-def test_imagedeid_pacs_complex_function_quarantines(tmp_path):
+def test_imagedeid_pacs_complex_function_quarantines(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1212,61 +1132,53 @@ def test_imagedeid_pacs_complex_function_quarantines(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, acc in enumerate(["ACC001", "ACC002"]):
+        ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, acc in enumerate(["ACC001", "ACC002"]):
-            ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 1, f"Expected 1 output file (mapped), got {len(output_files)}"
-        
-        ds = pydicom.dcmread(output_files[0])
-        assert ds.AccessionNumber == "MAPPED001", "Only mapped file should be in output"
-        
-        quarantine_dir = appdata_dir / "quarantine"
-        quarantined_files = list(quarantine_dir.rglob("*.dcm"))
-        assert len(quarantined_files) == 1, "Unmapped file with complex function should be quarantined"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 1, f"Expected 1 output file (mapped), got {len(output_files)}"
+    
+    ds = pydicom.dcmread(output_files[0])
+    assert ds.AccessionNumber == "MAPPED001", "Only mapped file should be in output"
+    
+    quarantine_dir = appdata_dir / "quarantine"
+    quarantined_files = list(quarantine_dir.rglob("*.dcm"))
+    assert len(quarantined_files) == 1, "Unmapped file with complex function should be quarantined"
+    
 
-
-def test_imagedeid_pacs_tag_not_in_script(tmp_path):
+def test_imagedeid_pacs_tag_not_in_script(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1283,63 +1195,55 @@ def test_imagedeid_pacs_tag_not_in_script(tmp_path):
     })
     df_mapping.to_excel(mapping_file, index=False)
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    for i, acc in enumerate(["ACC001", "ACC002", "ACC003"]):
+        ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        for i, acc in enumerate(["ACC001", "ACC002", "ACC003"]):
-            ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002", "ACC003"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
-        
-        accession_numbers = set()
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            accession_numbers.add(ds.AccessionNumber)
-        
-        assert "NEWACC001" in accession_numbers, "ACC001 should be mapped"
-        assert "NEWACC002" in accession_numbers, "ACC002 should be mapped"
-        assert "ACC003" in accession_numbers, "ACC003 should be kept (not in mapping, fallback to @keep() for new tags)"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 output files, got {len(output_files)}"
+    
+    accession_numbers = set()
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        accession_numbers.add(ds.AccessionNumber)
+    
+    assert "NEWACC001" in accession_numbers, "ACC001 should be mapped"
+    assert "NEWACC002" in accession_numbers, "ACC002 should be mapped"
+    assert "ACC003" in accession_numbers, "ACC003 should be kept (not in mapping, fallback to @keep() for new tags)"
+    
 
-
-def test_imagedeid_pacs_explicit_lookup_table_overrides_mapping_file(tmp_path):
+def test_imagedeid_pacs_explicit_lookup_table_overrides_mapping_file(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1358,58 +1262,50 @@ def test_imagedeid_pacs_explicit_lookup_table_overrides_mapping_file(tmp_path):
     
     explicit_lookup_table = """AccessionNumber/ACC001 = FROM_EXPLICIT"""
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds = _create_test_dicom("ACC001", "MRN0000", "Patient", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        ds = _create_test_dicom("ACC001", "MRN0000", "Patient", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@lookup(this,AccessionNumber,keep)</e>
 </script>"""
-        
-        imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            lookup_table=explicit_lookup_table,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        output_files = list(output_dir.rglob("*.dcm"))
-        assert len(output_files) == 1, f"Expected 1 output file, got {len(output_files)}"
-        
-        ds = pydicom.dcmread(output_files[0])
-        assert ds.AccessionNumber == "FROM_EXPLICIT", "Explicit lookup_table should override mapping_file_path"
-        assert ds.AccessionNumber != "FROM_MAPPING", "Mapping file should be ignored when explicit lookup_table is provided"
     
-    finally:
-        orthanc.stop()
+    imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        lookup_table=explicit_lookup_table,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+    
+    output_files = list(output_dir.rglob("*.dcm"))
+    assert len(output_files) == 1, f"Expected 1 output file, got {len(output_files)}"
+    
+    ds = pydicom.dcmread(output_files[0])
+    assert ds.AccessionNumber == "FROM_EXPLICIT", "Explicit lookup_table should override mapping_file_path"
+    assert ds.AccessionNumber != "FROM_MAPPING", "Mapping file should be ignored when explicit lookup_table is provided"
+    
 
-
-def test_imagedeid_pacs_cleans_up_getscu_temp(tmp_path):
+def test_imagedeid_pacs_cleans_up_getscu_temp(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
 
@@ -1451,7 +1347,7 @@ def test_imagedeid_pacs_cleans_up_getscu_temp(tmp_path):
         assert not getscu_temp.exists(), "getscu_temp should be removed after successful completion"
 
 
-def test_imagedeid_pacs_cleans_up_getscu_temp_on_error(tmp_path):
+def test_imagedeid_pacs_cleans_up_getscu_temp_on_error(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
 
@@ -1490,7 +1386,7 @@ def test_imagedeid_pacs_cleans_up_getscu_temp_on_error(tmp_path):
         assert not getscu_temp.exists(), "getscu_temp should be removed even when pipeline raises"
 
 
-def test_imagedeid_pacs_saves_failed_queries_csv(tmp_path):
+def test_imagedeid_pacs_saves_failed_queries_csv(tmp_path, orthanc):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
     
@@ -1500,65 +1396,57 @@ def test_imagedeid_pacs_saves_failed_queries_csv(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
     
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
     
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "ACC999"],
-            "PatientID": ["MRN001", "MRN999"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID"
-        )
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    time.sleep(2)
+    
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "ACC999"],
+        "PatientID": ["MRN001", "MRN999"]
+    })
+    query_df.to_excel(query_file, index=False)
+    
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID"
+    )
+    
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+    
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
-        
-        result = imagedeid_pacs(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 1
-        assert len(result["failed_query_indices"]) == 1
-        
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should exist"
-        
-        df = pd.read_csv(csv_path)
-        assert len(df) == 1
-        assert list(df.columns) == ["Accession Number", "MRN", "Failure Reason"]
-        assert df.loc[0, "Accession Number"] == "ACC999"
-        assert df.loc[0, "MRN"] == "MRN999"
-        assert df.loc[0, "Failure Reason"] == "Failed to find images"
     
-    finally:
-        orthanc.stop()
-
+    result = imagedeid_pacs(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+    
+    assert result["num_studies_found"] == 1
+    assert len(result["failed_query_indices"]) == 1
+    
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should exist"
+    
+    df = pd.read_csv(csv_path)
+    assert len(df) == 1
+    assert list(df.columns) == ["Accession Number", "MRN", "Failure Reason"]
+    assert df.loc[0, "Accession Number"] == "ACC999"
+    assert df.loc[0, "MRN"] == "MRN999"
+    assert df.loc[0, "Failure Reason"] == "Failed to find images"
+    
 

--- a/test_module_imagedeid_pacs.py
+++ b/test_module_imagedeid_pacs.py
@@ -223,7 +223,7 @@ def test_continuous_audit_log_saving(tmp_path):
         monitor_thread = threading.Thread(target=monitor_files, daemon=True)
         monitor_thread.start()
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -917,7 +917,7 @@ def test_imagedeid_pacs_with_mapping_file_basic(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@keep()</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1001,7 +1001,7 @@ def test_imagedeid_pacs_with_mapping_file_multiple_tags(tmp_path):
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1091,7 +1091,7 @@ def test_imagedeid_pacs_date_format_conversion_with_mapping(tmp_path):
 <e en="T" t="00080020" n="StudyDate">@keep()</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1168,7 +1168,7 @@ def test_imagedeid_pacs_fallback_to_simple_action(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@empty()</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1241,7 +1241,7 @@ def test_imagedeid_pacs_complex_function_quarantines(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1312,7 +1312,7 @@ def test_imagedeid_pacs_tag_not_in_script(tmp_path):
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -1386,7 +1386,7 @@ def test_imagedeid_pacs_explicit_lookup_table_overrides_mapping_file(tmp_path):
 <e en="T" t="00080050" n="AccessionNumber">@lookup(this,AccessionNumber,keep)</e>
 </script>"""
         
-        result = imagedeid_pacs(
+        imagedeid_pacs(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",

--- a/test_module_imagedeid_pacs.py
+++ b/test_module_imagedeid_pacs.py
@@ -9,9 +9,8 @@ import pandas as pd
 import pytest
 import pydicom
 
-from module_imagedeid_local import _generate_lookup_table_content
 from module_imagedeid_pacs import imagedeid_pacs
-from test_utils import cleanup_docker_containers, _create_test_dicom, _upload_dicom_to_orthanc, Fixtures, OrthancServer
+from test_utils import _create_test_dicom, _upload_dicom_to_orthanc, Fixtures, OrthancServer
 from utils import PacsConfiguration, Spreadsheet
 
 

--- a/test_module_imagedeidexport.py
+++ b/test_module_imagedeidexport.py
@@ -106,26 +106,26 @@ def test_imagedeidexport_basic_workflow(tmp_path):
 def test_imagedeidexport_preserves_metadata_and_dicoms(tmp_path):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
+
     orthanc = OrthancServer()
     orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
     orthanc.start()
-    
+
     azurite = AzuriteServer()
     azurite.start()
-    
+
     try:
         ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
         ds.InstanceNumber = 1
         _upload_dicom_to_orthanc(ds, orthanc)
-        
+
         time.sleep(2)
-        
+
         query_file = appdata_dir / "query.xlsx"
         query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
         query_df.to_excel(query_file, index=False)
@@ -150,7 +150,7 @@ def test_imagedeidexport_preserves_metadata_and_dicoms(tmp_path):
         
         from module_imagedeidexport import imagedeidexport
         
-        result = imagedeidexport(
+        imagedeidexport(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",

--- a/test_module_imagedeidexport.py
+++ b/test_module_imagedeidexport.py
@@ -15,95 +15,7 @@ from utils import PacsConfiguration, Spreadsheet
 logging.basicConfig(level=logging.INFO)
 
 
-def test_imagedeidexport_basic_workflow(tmp_path):
-    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
-    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
-    appdata_dir = tmp_path / "appdata"
-    appdata_dir.mkdir()
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        ds2 = _create_test_dicom("ACC002", "MRN002", "Patient2", "CT", "3.0")
-        ds2.InstanceNumber = 2
-        _upload_dicom_to_orthanc(ds2, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
-<e en="T" t="00100010" n="PatientName">@empty()</e>
-<e en="T" t="00100020" n="PatientID">@empty()</e>
-<e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
-</script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        result = imagedeidexport(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 2
-        assert result["num_images_exported"] == 2
-        
-        blobs = azurite.list_blobs(container_name)
-        assert len(blobs) == 2
-        for blob in blobs:
-            assert blob.startswith(f"{project_name}/")
-            assert blob.endswith(".dcm")
-        
-        metadata_files = ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]
-        for metadata_file in metadata_files:
-            metadata_path = appdata_dir / metadata_file
-            assert metadata_path.exists(), f"{metadata_file} should exist in appdata"
-        
-        quarantine_dir = appdata_dir / "quarantine"
-        assert quarantine_dir.exists()
-        
-        dcm_files_in_output = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files_in_output) == 2, "Deidentified DICOM files should be preserved in output_dir"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
-
-
-def test_imagedeidexport_preserves_metadata_and_dicoms(tmp_path):
+def test_imagedeidexport_basic_workflow(tmp_path, orthanc, azurite):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
 
@@ -112,352 +24,377 @@ def test_imagedeidexport_preserves_metadata_and_dicoms(tmp_path):
     output_dir = tmp_path / "output"
     output_dir.mkdir()
 
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds1, orthanc)
 
-    azurite = AzuriteServer()
-    azurite.start()
+    ds2 = _create_test_dicom("ACC002", "MRN002", "Patient2", "CT", "3.0")
+    ds2.InstanceNumber = 2
+    _upload_dicom_to_orthanc(ds2, orthanc)
 
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
+    time.sleep(2)
 
-        time.sleep(2)
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
 </script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    result = imagedeidexport(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    assert result["num_studies_found"] == 2
+    assert result["num_images_exported"] == 2
+
+    blobs = azurite.list_blobs(container_name)
+    assert len(blobs) == 2
+    for blob in blobs:
+        assert blob.startswith(f"{project_name}/")
+        assert blob.endswith(".dcm")
+
+    metadata_files = ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]
+    for metadata_file in metadata_files:
+        metadata_path = appdata_dir / metadata_file
+        assert metadata_path.exists(), f"{metadata_file} should exist in appdata"
+
+    quarantine_dir = appdata_dir / "quarantine"
+    assert quarantine_dir.exists()
+
+    dcm_files_in_output = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files_in_output) == 2, "Deidentified DICOM files should be preserved in output_dir"
+
+
+def test_imagedeidexport_preserves_metadata_and_dicoms(tmp_path, orthanc, azurite):
+    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
+    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
+
+    appdata_dir = tmp_path / "appdata"
+    appdata_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
+<e en="T" t="00100010" n="PatientName">@empty()</e>
+<e en="T" t="00100020" n="PatientID">@empty()</e>
+<e en="T" t="00080050" n="AccessionNumber">@hashPtID(@UID(),13)</e>
+</script>"""
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    imagedeidexport(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    metadata_files = ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]
+    for metadata_file in metadata_files:
+        metadata_path = appdata_dir / metadata_file
+        assert metadata_path.exists(), f"{metadata_file} should be preserved in appdata"
+        assert metadata_path.stat().st_size > 0, f"{metadata_file} should not be empty"
+
+    dcm_files_in_output = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files_in_output) == 1, "Deidentified DICOM files should be preserved in output_dir"
+
+    quarantine_dir = appdata_dir / "quarantine"
+    if quarantine_dir.exists():
+        quarantine_files = list(quarantine_dir.rglob("*.dcm"))
+        for qfile in quarantine_files:
+            assert "quarantine" in str(qfile), "Quarantined files should be in quarantine subdirectory"
+
+    blobs = azurite.list_blobs(container_name)
+    assert len(blobs) == 1, "Exactly 1 DICOM file should be uploaded to Azure"
+
+
+def test_imagedeidexport_handles_pacs_failures(tmp_path, azurite):
+    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
+    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
+
+    appdata_dir = tmp_path / "appdata"
+    appdata_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    invalid_pacs_config = PacsConfiguration(
+        host="invalid-host.local",
+        port=99999,
+        aet="INVALID"
+    )
+
+    anonymizer_script = """<script>
+<e en="T" t="00100010" n="PatientName">@empty()</e>
+</script>"""
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    result = imagedeidexport(
+        pacs_list=[invalid_pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    assert result["num_studies_found"] == 0
+    assert result["num_images_exported"] == 0
+    assert len(result["failed_query_indices"]) == 2
+
+    blobs = azurite.list_blobs(container_name)
+    assert len(blobs) == 0, "No files should be uploaded when PACS queries fail"
+
+
+def test_imagedeidexport_handles_export_failures(tmp_path, orthanc):
+    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
+    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
+
+    appdata_dir = tmp_path / "appdata"
+    appdata_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
+<e en="T" t="00100010" n="PatientName">@empty()</e>
+</script>"""
+
+    invalid_sas_url = "http://invalid-storage.blob.core.windows.net/container?invalidtoken"
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    with pytest.raises(Exception) as exc_info:
         imagedeidexport(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
-            sas_url=sas_url,
+            sas_url=invalid_sas_url,
             project_name=project_name,
             output_dir=str(output_dir),
             appdata_dir=str(appdata_dir),
             anonymizer_script=anonymizer_script,
             apply_default_filter_script=False
         )
-        
-        metadata_files = ["metadata.xlsx", "deid_metadata.xlsx", "linker.xlsx"]
-        for metadata_file in metadata_files:
-            metadata_path = appdata_dir / metadata_file
-            assert metadata_path.exists(), f"{metadata_file} should be preserved in appdata"
-            assert metadata_path.stat().st_size > 0, f"{metadata_file} should not be empty"
-        
-        dcm_files_in_output = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files_in_output) == 1, "Deidentified DICOM files should be preserved in output_dir"
-        
-        quarantine_dir = appdata_dir / "quarantine"
-        if quarantine_dir.exists():
-            quarantine_files = list(quarantine_dir.rglob("*.dcm"))
-            for qfile in quarantine_files:
-                assert "quarantine" in str(qfile), "Quarantined files should be in quarantine subdirectory"
-        
-        blobs = azurite.list_blobs(container_name)
-        assert len(blobs) == 1, "Exactly 1 DICOM file should be uploaded to Azure"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+
+    error_msg = str(exc_info.value).lower()
+    assert "rclone" in error_msg or "error" in error_msg
 
 
-def test_imagedeidexport_handles_pacs_failures(tmp_path):
+def test_imagedeidexport_with_filter_script(tmp_path, orthanc, azurite):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        invalid_pacs_config = PacsConfiguration(
-            host="invalid-host.local",
-            port=99999,
-            aet="INVALID"
-        )
-        
-        anonymizer_script = """<script>
-<e en="T" t="00100010" n="PatientName">@empty()</e>
-</script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        result = imagedeidexport(
-            pacs_list=[invalid_pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 0
-        assert result["num_images_exported"] == 0
-        assert len(result["failed_query_indices"]) == 2
-        
-        blobs = azurite.list_blobs(container_name)
-        assert len(blobs) == 0, "No files should be uploaded when PACS queries fail"
-    
-    finally:
-        azurite.stop()
 
-
-def test_imagedeidexport_handles_export_failures(tmp_path):
-    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
-    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
-    appdata_dir = tmp_path / "appdata"
-    appdata_dir.mkdir()
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
+    for i, slice_thickness in enumerate(["0.5", "3.0", "5.0"]):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", slice_thickness)
+        ds.InstanceNumber = i + 1
         _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC000", "ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        invalid_sas_url = "http://invalid-storage.blob.core.windows.net/container?invalidtoken"
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        with pytest.raises(Exception) as exc_info:
-            imagedeidexport(
-                pacs_list=[pacs_config],
-                query_spreadsheet=query_spreadsheet,
-                application_aet="TEST_AET",
-                sas_url=invalid_sas_url,
-                project_name=project_name,
-                output_dir=str(output_dir),
-                appdata_dir=str(appdata_dir),
-                anonymizer_script=anonymizer_script,
-                apply_default_filter_script=False
-            )
-        
-        error_msg = str(exc_info.value).lower()
-        assert "rclone" in error_msg or "error" in error_msg
-    
-    finally:
-        orthanc.stop()
+
+    filter_script = 'SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    result = imagedeidexport(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        filter_script=filter_script,
+        apply_default_filter_script=False
+    )
+
+    assert result["num_studies_found"] == 3
+    assert result["num_images_exported"] == 1
+    assert result["num_images_quarantined"] == 2
+
+    blobs = azurite.list_blobs(container_name)
+    assert len(blobs) == 1, "Only 1 file matching filter should be exported"
 
 
-def test_imagedeidexport_with_filter_script(tmp_path):
+def test_imagedeidexport_with_mapping_file(tmp_path, orthanc, azurite):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
-    appdata_dir = tmp_path / "appdata"
-    appdata_dir.mkdir()
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        for i, slice_thickness in enumerate(["0.5", "3.0", "5.0"]):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", slice_thickness)
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC000", "ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
-<e en="T" t="00100010" n="PatientName">@empty()</e>
-</script>"""
-        
-        filter_script = 'SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        result = imagedeidexport(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            filter_script=filter_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 3
-        assert result["num_images_exported"] == 1
-        assert result["num_images_quarantined"] == 2
-        
-        blobs = azurite.list_blobs(container_name)
-        assert len(blobs) == 1, "Only 1 file matching filter should be exported"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
 
-
-def test_imagedeidexport_with_mapping_file(tmp_path):
-    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
-    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
     mapping_file = tmp_path / "mapping.xlsx"
-    
+
     df_mapping = pd.DataFrame({
         "AccessionNumber": ["ACC001", "ACC002"],
         "New-AccessionNumber": ["MAPPED001", "MAPPED002"]
     })
     df_mapping.to_excel(mapping_file, index=False)
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        for i, acc in enumerate(["ACC001", "ACC002"]):
-            ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    for i, acc in enumerate(["ACC001", "ACC002"]):
+        ds = _create_test_dicom(acc, f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC002"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00080050" n="AccessionNumber">@keep()</e>
 </script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        result = imagedeidexport(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            mapping_file_path=str(mapping_file),
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 2
-        assert result["num_images_exported"] == 2
-        
-        blobs = azurite.list_blobs(container_name)
-        assert len(blobs) == 2
-        
-        for blob in blobs:
-            blob_content = azurite.get_blob_content(container_name, blob)
-            ds = pydicom.dcmread(DicomBytesIO(blob_content))
-            assert ds.AccessionNumber in ["MAPPED001", "MAPPED002"]
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    result = imagedeidexport(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        mapping_file_path=str(mapping_file),
+        apply_default_filter_script=False
+    )
+
+    assert result["num_studies_found"] == 2
+    assert result["num_images_exported"] == 2
+
+    blobs = azurite.list_blobs(container_name)
+    assert len(blobs) == 2
+
+    for blob in blobs:
+        blob_content = azurite.get_blob_content(container_name, blob)
+        ds = pydicom.dcmread(DicomBytesIO(blob_content))
+        assert ds.AccessionNumber in ["MAPPED001", "MAPPED002"]
 
 
 def test_imagedeidexport_with_multiple_pacs(tmp_path):
@@ -541,77 +478,65 @@ def test_imagedeidexport_with_multiple_pacs(tmp_path):
         azurite.stop()
 
 
-def test_imagedeidexport_saves_failed_queries_csv(tmp_path):
+def test_imagedeidexport_saves_failed_queries_csv(tmp_path, orthanc, azurite):
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC999"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds1, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC999"]})
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
-        
-        from module_imagedeidexport import imagedeidexport
-        
-        result = imagedeidexport(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["num_studies_found"] == 1
-        assert len(result["failed_query_indices"]) == 1
-        
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should be created by imagedeid_pacs"
-        
-        df = pd.read_csv(csv_path)
-        assert len(df) == 1
-        assert df.loc[0, "Accession Number"] == "ACC999"
-        assert df.loc[0, "Failure Reason"] == "Failed to find images"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_imagedeidexport import imagedeidexport
+
+    result = imagedeidexport(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    assert result["num_studies_found"] == 1
+    assert len(result["failed_query_indices"]) == 1
+
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should be created by imagedeid_pacs"
+
+    df = pd.read_csv(csv_path)
+    assert len(df) == 1
+    assert df.loc[0, "Accession Number"] == "ACC999"
+    assert df.loc[0, "Failure Reason"] == "Failed to find images"
 
 

--- a/test_module_imagedeidexport.py
+++ b/test_module_imagedeidexport.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pydicom
 import pytest
+from pydicom.filebase import DicomBytesIO
 
 from test_utils import _create_test_dicom, _upload_dicom_to_orthanc, AzuriteServer, OrthancServer
 from utils import PacsConfiguration, Spreadsheet
@@ -451,7 +452,7 @@ def test_imagedeidexport_with_mapping_file(tmp_path):
         
         for blob in blobs:
             blob_content = azurite.get_blob_content(container_name, blob)
-            ds = pydicom.dcmread(pydicom.filebase.DicomBytesIO(blob_content))
+            ds = pydicom.dcmread(DicomBytesIO(blob_content))
             assert ds.AccessionNumber in ["MAPPED001", "MAPPED002"]
     
     finally:

--- a/test_module_imageqr.py
+++ b/test_module_imageqr.py
@@ -19,168 +19,152 @@ from dcmtk import get_study
 logging.basicConfig(level=logging.INFO)
 
 
-def test_imageqr_pacs_with_accession_filter(tmp_path):
+def test_imageqr_pacs_with_accession_filter(tmp_path, orthanc):
     """Test imageqr with filter script that filters by modality and slice thickness."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(3):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "0.5")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
 
-        for i in range(3, 6):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
+    for i in range(3):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "0.5")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
 
-        for i in range(6, 9):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "MR", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
+    for i in range(3, 6):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(9)]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    for i in range(6, 9):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "MR", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(9)]})
+    query_df.to_excel(query_file, index=False)
 
-        filter_script = 'Modality.contains("CT") * SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            filter_script=filter_script
-        )
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        images_dir = output_dir / "images"
-        output_files = list(images_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
+    filter_script = 'Modality.contains("CT") * SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
 
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            assert ds.Modality == "CT", "Modality should be CT"
-            assert float(ds.SliceThickness) > 1 and float(ds.SliceThickness) < 5, "SliceThickness should be between 1 and 5"
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        filter_script=filter_script
+    )
 
-        metadata_path = appdata_dir / "metadata.xlsx"
-        assert metadata_path.exists(), "metadata.xlsx should exist"
+    images_dir = output_dir / "images"
+    output_files = list(images_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
 
-        metadata_df = pd.read_excel(metadata_path)
-        assert len(metadata_df) >= 3, "metadata.xlsx should have at least 3 rows"
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        assert ds.Modality == "CT", "Modality should be CT"
+        assert float(ds.SliceThickness) > 1 and float(ds.SliceThickness) < 5, "SliceThickness should be between 1 and 5"
 
-        assert result["num_studies_found"] >= 3
-        assert result["num_images_saved"] == 3
+    metadata_path = appdata_dir / "metadata.xlsx"
+    assert metadata_path.exists(), "metadata.xlsx should exist"
 
-        quarantine_dir = appdata_dir / "quarantine"
-        assert quarantine_dir.exists(), "Quarantine directory should exist in appdata"
+    metadata_df = pd.read_excel(metadata_path)
+    assert len(metadata_df) >= 3, "metadata.xlsx should have at least 3 rows"
 
-        quarantined_files = list(quarantine_dir.rglob("*.dcm"))
-        assert len(quarantined_files) == 6, f"Expected 6 quarantined files, found {len(quarantined_files)}"
+    assert result["num_studies_found"] >= 3
+    assert result["num_images_saved"] == 3
 
-        for file in quarantined_files:
-            ds = pydicom.dcmread(file)
-            assert ds.Modality in ["CT", "MR"], "Quarantined file should be either CT or MR"
-            if ds.Modality == "CT":
-                slice_thickness = float(ds.SliceThickness)
-                assert slice_thickness <= 1.0 or slice_thickness >= 5.0, f"Quarantined CT should have slice thickness <=1 or >=5, got {slice_thickness}"
-            else:
-                assert ds.Modality == "MR", "Non-CT quarantined file should be MR"
-    
-    finally:
-        orthanc.stop()
+    quarantine_dir = appdata_dir / "quarantine"
+    assert quarantine_dir.exists(), "Quarantine directory should exist in appdata"
+
+    quarantined_files = list(quarantine_dir.rglob("*.dcm"))
+    assert len(quarantined_files) == 6, f"Expected 6 quarantined files, found {len(quarantined_files)}"
+
+    for file in quarantined_files:
+        ds = pydicom.dcmread(file)
+        assert ds.Modality in ["CT", "MR"], "Quarantined file should be either CT or MR"
+        if ds.Modality == "CT":
+            slice_thickness = float(ds.SliceThickness)
+            assert slice_thickness <= 1.0 or slice_thickness >= 5.0, f"Quarantined CT should have slice thickness <=1 or >=5, got {slice_thickness}"
+        else:
+            assert ds.Modality == "MR", "Non-CT quarantined file should be MR"
 
 
-def test_continuous_audit_log_saving(tmp_path):
+def test_continuous_audit_log_saving(tmp_path, orthanc):
     """Test that metadata file is saved continuously during processing."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        for i in range(5):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(5)]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    for i in range(5):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", "3.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(5)]})
+    query_df.to_excel(query_file, index=False)
 
-        file_write_times = {}
-        lock = threading.Lock()
-        stop_monitoring = threading.Event()
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        def monitor_files():
-            while not stop_monitoring.is_set():
-                filepath = appdata_dir / "metadata.xlsx"
-                if filepath.exists():
-                    mtime = os.path.getmtime(filepath)
-                    with lock:
-                        if "metadata.xlsx" not in file_write_times:
-                            file_write_times["metadata.xlsx"] = []
-                        if not file_write_times["metadata.xlsx"] or mtime != file_write_times["metadata.xlsx"][-1]:
-                            file_write_times["metadata.xlsx"].append(mtime)
-                time.sleep(1)
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        monitor_thread = threading.Thread(target=monitor_files, daemon=True)
-        monitor_thread.start()
+    file_write_times = {}
+    lock = threading.Lock()
+    stop_monitoring = threading.Event()
 
-        imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir)
-        )
+    def monitor_files():
+        while not stop_monitoring.is_set():
+            filepath = appdata_dir / "metadata.xlsx"
+            if filepath.exists():
+                mtime = os.path.getmtime(filepath)
+                with lock:
+                    if "metadata.xlsx" not in file_write_times:
+                        file_write_times["metadata.xlsx"] = []
+                    if not file_write_times["metadata.xlsx"] or mtime != file_write_times["metadata.xlsx"][-1]:
+                        file_write_times["metadata.xlsx"].append(mtime)
+            time.sleep(1)
 
-        stop_monitoring.set()
-        monitor_thread.join(timeout=2)
+    monitor_thread = threading.Thread(target=monitor_files, daemon=True)
+    monitor_thread.start()
 
-        with lock:
-            write_count = len(file_write_times.get("metadata.xlsx", []))
-            assert write_count >= 2, f"metadata.xlsx should have been written multiple times (found {write_count} writes), indicating continuous saving"
+    imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir)
+    )
 
-        assert (appdata_dir / "metadata.xlsx").exists()
-    
-    finally:
-        orthanc.stop()
+    stop_monitoring.set()
+    monitor_thread.join(timeout=2)
+
+    with lock:
+        write_count = len(file_write_times.get("metadata.xlsx", []))
+        assert write_count >= 2, f"metadata.xlsx should have been written multiple times (found {write_count} writes), indicating continuous saving"
+
+    assert (appdata_dir / "metadata.xlsx").exists()
 
 
 def test_imageqr_failures_reported(tmp_path):
@@ -368,432 +352,392 @@ def test_imageqr_multiple_pacs(tmp_path):
         orthanc2.stop()
 
 
-def test_imageqr_pacs_mrn_study_date_fallback(tmp_path):
+def test_imageqr_pacs_mrn_study_date_fallback(tmp_path, orthanc):
     """Test fallback to MRN/StudyDate query when accession is missing."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
 
-        ds = _create_test_dicom("", "MRN002", "Patient2", "CT", "3.0")
-        ds.InstanceNumber = 2
-        _upload_dicom_to_orthanc(ds, orthanc)
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
 
-        ds = _create_test_dicom("", "MRN003", "Patient3", "CT", "3.0")
-        ds.InstanceNumber = 3
-        _upload_dicom_to_orthanc(ds, orthanc)
+    ds = _create_test_dicom("", "MRN002", "Patient2", "CT", "3.0")
+    ds.InstanceNumber = 2
+    _upload_dicom_to_orthanc(ds, orthanc)
 
-        query_file = appdata_dir / "query_valid.xlsx"
-        query_data = {
-            "AccessionNumber": ["ACC001", None, None],
-            "PatientID": ["MRN001", "MRN002", "MRN003"],
-            "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
-        }
-        query_df = pd.DataFrame(query_data)
-        query_df.to_excel(query_file, index=False)
+    ds = _create_test_dicom("", "MRN003", "Patient3", "CT", "3.0")
+    ds.InstanceNumber = 3
+    _upload_dicom_to_orthanc(ds, orthanc)
 
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
+    query_file = appdata_dir / "query_valid.xlsx"
+    query_data = {
+        "AccessionNumber": ["ACC001", None, None],
+        "PatientID": ["MRN001", "MRN002", "MRN003"],
+        "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
+    }
+    query_df = pd.DataFrame(query_data)
+    query_df.to_excel(query_file, index=False)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
 
-        result = imageqr(
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir)
+    )
+
+    assert result["num_studies_found"] == 3, f"Should find 3 studies, found {result['num_studies_found']}"
+    assert result["num_images_saved"] == 3, f"Should save 3 images, saved {result['num_images_saved']}"
+
+    images_dir = output_dir / "images"
+    output_files = list(images_dir.rglob("*.dcm"))
+    assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
+
+    query_file_invalid = appdata_dir / "query_invalid.xlsx"
+    query_data_invalid = {
+        "AccessionNumber": ["ACC001", None, None, None],
+        "PatientID": ["MRN001", "MRN002", "MRN003", "MRN004"],
+        "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), "invalid-date"]
+    }
+    query_df_invalid = pd.DataFrame(query_data_invalid)
+    query_df_invalid.to_excel(query_file_invalid, index=False)
+
+    query_spreadsheet_invalid = Spreadsheet.from_file(
+        str(query_file_invalid),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
+
+    with pytest.raises(ValueError, match="StudyDate must be in Excel date format"):
+        imageqr(
             pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
+            query_spreadsheet=query_spreadsheet_invalid,
             application_aet="TEST_AET",
             output_dir=str(output_dir),
             appdata_dir=str(appdata_dir)
         )
 
-        assert result["num_studies_found"] == 3, f"Should find 3 studies, found {result['num_studies_found']}"
-        assert result["num_images_saved"] == 3, f"Should save 3 images, saved {result['num_images_saved']}"
 
-        images_dir = output_dir / "images"
-        output_files = list(images_dir.rglob("*.dcm"))
-        assert len(output_files) == 3, f"Expected 3 .dcm files, found {len(output_files)}"
-
-        query_file_invalid = appdata_dir / "query_invalid.xlsx"
-        query_data_invalid = {
-            "AccessionNumber": ["ACC001", None, None, None],
-            "PatientID": ["MRN001", "MRN002", "MRN003", "MRN004"],
-            "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01"), "invalid-date"]
-        }
-        query_df_invalid = pd.DataFrame(query_data_invalid)
-        query_df_invalid.to_excel(query_file_invalid, index=False)
-
-        query_spreadsheet_invalid = Spreadsheet.from_file(
-            str(query_file_invalid),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
-
-        with pytest.raises(ValueError, match="StudyDate must be in Excel date format"):
-            imageqr(
-                pacs_list=[pacs_config],
-                query_spreadsheet=query_spreadsheet_invalid,
-                application_aet="TEST_AET",
-                output_dir=str(output_dir),
-                appdata_dir=str(appdata_dir)
-            )
-    
-    finally:
-        orthanc.stop()
-
-
-def test_imageqr_pacs_date_window(tmp_path):
+def test_imageqr_pacs_date_window(tmp_path, orthanc):
     """Test date window functionality for MRN/date queries."""
     import numpy as np
-    
+
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        dicom1 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250101",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        dicom1.InstanceNumber = 1
-        dicom1.SamplesPerPixel = 1
-        dicom1.PhotometricInterpretation = "MONOCHROME2"
-        dicom1.Rows = 64
-        dicom1.Columns = 64
-        dicom1.BitsAllocated = 16
-        dicom1.BitsStored = 16
-        dicom1.HighBit = 15
-        dicom1.PixelRepresentation = 0
-        dicom1.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(dicom1, orthanc)
 
-        dicom2 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250103",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        dicom2.InstanceNumber = 2
-        dicom2.SamplesPerPixel = 1
-        dicom2.PhotometricInterpretation = "MONOCHROME2"
-        dicom2.Rows = 64
-        dicom2.Columns = 64
-        dicom2.BitsAllocated = 16
-        dicom2.BitsStored = 16
-        dicom2.HighBit = 15
-        dicom2.PixelRepresentation = 0
-        dicom2.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(dicom2, orthanc)
+    dicom1 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250101",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    dicom1.InstanceNumber = 1
+    dicom1.SamplesPerPixel = 1
+    dicom1.PhotometricInterpretation = "MONOCHROME2"
+    dicom1.Rows = 64
+    dicom1.Columns = 64
+    dicom1.BitsAllocated = 16
+    dicom1.BitsStored = 16
+    dicom1.HighBit = 15
+    dicom1.PixelRepresentation = 0
+    dicom1.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(dicom1, orthanc)
 
-        dicom3 = Fixtures.create_minimal_dicom(
-            patient_id="MRN001",
-            patient_name="Patient1",
-            accession="",
-            study_date="20250110",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        dicom3.InstanceNumber = 3
-        dicom3.SamplesPerPixel = 1
-        dicom3.PhotometricInterpretation = "MONOCHROME2"
-        dicom3.Rows = 64
-        dicom3.Columns = 64
-        dicom3.BitsAllocated = 16
-        dicom3.BitsStored = 16
-        dicom3.HighBit = 15
-        dicom3.PixelRepresentation = 0
-        dicom3.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(dicom3, orthanc)
+    dicom2 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250103",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    dicom2.InstanceNumber = 2
+    dicom2.SamplesPerPixel = 1
+    dicom2.PhotometricInterpretation = "MONOCHROME2"
+    dicom2.Rows = 64
+    dicom2.Columns = 64
+    dicom2.BitsAllocated = 16
+    dicom2.BitsStored = 16
+    dicom2.HighBit = 15
+    dicom2.PixelRepresentation = 0
+    dicom2.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(dicom2, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": [None],
-            "PatientID": ["MRN001"],
-            "StudyDate": [pd.Timestamp("2025-01-03")]
-        })
-        query_df.to_excel(query_file, index=False)
+    dicom3 = Fixtures.create_minimal_dicom(
+        patient_id="MRN001",
+        patient_name="Patient1",
+        accession="",
+        study_date="20250110",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    dicom3.InstanceNumber = 3
+    dicom3.SamplesPerPixel = 1
+    dicom3.PhotometricInterpretation = "MONOCHROME2"
+    dicom3.Rows = 64
+    dicom3.Columns = 64
+    dicom3.BitsAllocated = 16
+    dicom3.BitsStored = 16
+    dicom3.HighBit = 15
+    dicom3.PixelRepresentation = 0
+    dicom3.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(dicom3, orthanc)
 
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": [None],
+        "PatientID": ["MRN001"],
+        "StudyDate": [pd.Timestamp("2025-01-03")]
+    })
+    query_df.to_excel(query_file, index=False)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            date_window_days=2
-        )
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        images_dir = output_dir / "images"
-        output_files = list(images_dir.rglob("*.dcm"))
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        date_window_days=2
+    )
 
-        study_dates_found = set()
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            study_dates_found.add(ds.StudyDate)
+    images_dir = output_dir / "images"
+    output_files = list(images_dir.rglob("*.dcm"))
 
-        assert result["num_studies_found"] >= 2, f"Should find at least 2 studies within 2-day window, found {result['num_studies_found']}"
-        assert result["num_images_saved"] >= 2, f"Should save at least 2 images, saved {result['num_images_saved']}"
-        assert "20250101" in study_dates_found and "20250103" in study_dates_found, f"Should find both studies within 2-day window. Found dates: {study_dates_found}"
-        assert "20250110" not in study_dates_found, f"Should not find study outside window. Found dates: {study_dates_found}"
-    
-    finally:
-        orthanc.stop()
+    study_dates_found = set()
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        study_dates_found.add(ds.StudyDate)
+
+    assert result["num_studies_found"] >= 2, f"Should find at least 2 studies within 2-day window, found {result['num_studies_found']}"
+    assert result["num_images_saved"] >= 2, f"Should save at least 2 images, saved {result['num_images_saved']}"
+    assert "20250101" in study_dates_found and "20250103" in study_dates_found, f"Should find both studies within 2-day window. Found dates: {study_dates_found}"
+    assert "20250110" not in study_dates_found, f"Should not find study outside window. Found dates: {study_dates_found}"
 
 
-def test_imageqr_accession_wildcard_filtering(tmp_path):
+def test_imageqr_accession_wildcard_filtering(tmp_path, orthanc):
     """Test that accession number matching uses wildcards correctly."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        dicom1 = _create_test_dicom("  ABC001  ", "MRN001", "Patient1", "CT", "3.0")
-        dicom1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(dicom1, orthanc)
 
-        dicom2 = _create_test_dicom("ABC001", "MRN002", "Patient2", "CT", "3.0")
-        dicom2.InstanceNumber = 2
-        _upload_dicom_to_orthanc(dicom2, orthanc)
+    dicom1 = _create_test_dicom("  ABC001  ", "MRN001", "Patient1", "CT", "3.0")
+    dicom1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(dicom1, orthanc)
 
-        dicom3 = _create_test_dicom("12ABC0011", "MRN003", "Patient3", "CT", "3.0")
-        dicom3.InstanceNumber = 3
-        _upload_dicom_to_orthanc(dicom3, orthanc)
+    dicom2 = _create_test_dicom("ABC001", "MRN002", "Patient2", "CT", "3.0")
+    dicom2.InstanceNumber = 2
+    _upload_dicom_to_orthanc(dicom2, orthanc)
 
-        dicom4 = _create_test_dicom("ABC001ABC", "MRN004", "Patient4", "CT", "3.0")
-        dicom4.InstanceNumber = 4
-        _upload_dicom_to_orthanc(dicom4, orthanc)
+    dicom3 = _create_test_dicom("12ABC0011", "MRN003", "Patient3", "CT", "3.0")
+    dicom3.InstanceNumber = 3
+    _upload_dicom_to_orthanc(dicom3, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ABC001"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    dicom4 = _create_test_dicom("ABC001ABC", "MRN004", "Patient4", "CT", "3.0")
+    dicom4.InstanceNumber = 4
+    _upload_dicom_to_orthanc(dicom4, orthanc)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ABC001"]})
+    query_df.to_excel(query_file, index=False)
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir)
-        )
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        images_dir = output_dir / "images"
-        output_files = list(images_dir.rglob("*.dcm"))
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        assert result["num_studies_found"] == 2, f"Should find exactly 2 studies (with exact match and whitespace), found {result['num_studies_found']}"
-        assert len(output_files) == 2, f"Expected 2 .dcm files, found {len(output_files)}"
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir)
+    )
 
-        found_accessions = set()
-        for file in output_files:
-            ds = pydicom.dcmread(file)
-            found_accessions.add(ds.AccessionNumber.strip())
+    images_dir = output_dir / "images"
+    output_files = list(images_dir.rglob("*.dcm"))
 
-        assert found_accessions == {"ABC001"}, f"Should only find studies with exact AccessionNumber 'ABC001' (after trimming), found: {found_accessions}"
-    
-    finally:
-        orthanc.stop()
+    assert result["num_studies_found"] == 2, f"Should find exactly 2 studies (with exact match and whitespace), found {result['num_studies_found']}"
+    assert len(output_files) == 2, f"Expected 2 .dcm files, found {len(output_files)}"
+
+    found_accessions = set()
+    for file in output_files:
+        ds = pydicom.dcmread(file)
+        found_accessions.add(ds.AccessionNumber.strip())
+
+    assert found_accessions == {"ABC001"}, f"Should only find studies with exact AccessionNumber 'ABC001' (after trimming), found: {found_accessions}"
 
 
-def test_imageqr_saves_failed_queries_csv_on_find_failure(tmp_path):
+def test_imageqr_saves_failed_queries_csv_on_find_failure(tmp_path, orthanc):
     """Test that failed queries are saved to CSV with appropriate failure reasons."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        dicom = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        dicom.InstanceNumber = 1
-        _upload_dicom_to_orthanc(dicom, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC999", "ACC998"]})
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    dicom = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    dicom.InstanceNumber = 1
+    _upload_dicom_to_orthanc(dicom, orthanc)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": ["ACC001", "ACC999", "ACC998"]})
+    query_df.to_excel(query_file, index=False)
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir)
-        )
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        assert result["num_studies_found"] == 1
-        assert len(result["failed_query_indices"]) == 2
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should exist"
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir)
+    )
 
-        df = pd.read_csv(csv_path)
-        assert len(df) == 2
-        assert list(df.columns) == ["Accession Number", "Failure Reason"]
-        assert df.loc[0, "Accession Number"] == "ACC999"
-        assert df.loc[0, "Failure Reason"] == "Failed to find images"
-        assert df.loc[1, "Accession Number"] == "ACC998"
-        assert df.loc[1, "Failure Reason"] == "Failed to find images"
-    
-    finally:
-        orthanc.stop()
+    assert result["num_studies_found"] == 1
+    assert len(result["failed_query_indices"]) == 2
+
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should exist"
+
+    df = pd.read_csv(csv_path)
+    assert len(df) == 2
+    assert list(df.columns) == ["Accession Number", "Failure Reason"]
+    assert df.loc[0, "Accession Number"] == "ACC999"
+    assert df.loc[0, "Failure Reason"] == "Failed to find images"
+    assert df.loc[1, "Accession Number"] == "ACC998"
+    assert df.loc[1, "Failure Reason"] == "Failed to find images"
 
 
-def test_imageqr_saves_failed_queries_csv_with_mrn_date(tmp_path):
+def test_imageqr_saves_failed_queries_csv_with_mrn_date(tmp_path, orthanc):
     """Test that failed queries CSV works with MRN/Date columns."""
     import numpy as np
-    
+
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     output_dir = tmp_path / "output"
     appdata_dir = tmp_path / "appdata"
-    
+
     output_dir.mkdir()
     appdata_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        dicom = Fixtures.create_minimal_dicom(
-            accession="",
-            patient_id="MRN001",
-            patient_name="Patient1",
-            study_date="20250115",
-            modality="CT",
-            SliceThickness="3.0"
-        )
-        dicom.InstanceNumber = 1
-        dicom.SamplesPerPixel = 1
-        dicom.PhotometricInterpretation = "MONOCHROME2"
-        dicom.Rows = 64
-        dicom.Columns = 64
-        dicom.BitsAllocated = 16
-        dicom.BitsStored = 16
-        dicom.HighBit = 15
-        dicom.PixelRepresentation = 0
-        dicom.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
-        _upload_dicom_to_orthanc(dicom, orthanc)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "PatientID": ["MRN001", "MRN999"],
-            "StudyDate": [pd.Timestamp("2025-01-15"), pd.Timestamp("2025-02-20")]
-        })
-        query_df.to_excel(query_file, index=False)
+    dicom = Fixtures.create_minimal_dicom(
+        accession="",
+        patient_id="MRN001",
+        patient_name="Patient1",
+        study_date="20250115",
+        modality="CT",
+        SliceThickness="3.0"
+    )
+    dicom.InstanceNumber = 1
+    dicom.SamplesPerPixel = 1
+    dicom.PhotometricInterpretation = "MONOCHROME2"
+    dicom.Rows = 64
+    dicom.Columns = 64
+    dicom.BitsAllocated = 16
+    dicom.BitsStored = 16
+    dicom.HighBit = 15
+    dicom.PixelRepresentation = 0
+    dicom.PixelData = np.random.randint(0, 1000, (64, 64), dtype=np.uint16).tobytes()
+    _upload_dicom_to_orthanc(dicom, orthanc)
 
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "PatientID": ["MRN001", "MRN999"],
+        "StudyDate": [pd.Timestamp("2025-01-15"), pd.Timestamp("2025-02-20")]
+    })
+    query_df.to_excel(query_file, index=False)
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir)
-        )
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        assert result["num_studies_found"] == 1
-        assert len(result["failed_query_indices"]) == 1
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir)
+    )
 
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should exist"
+    assert result["num_studies_found"] == 1
+    assert len(result["failed_query_indices"]) == 1
 
-        df = pd.read_csv(csv_path)
-        assert len(df) == 1
-        assert list(df.columns) == ["MRN", "Date", "Failure Reason"]
-        assert df.loc[0, "MRN"] == "MRN999"
-        assert df.loc[0, "Date"] == "2025-02-20"
-        assert df.loc[0, "Failure Reason"] == "Failed to find images"
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should exist"
 
-    finally:
-        orthanc.stop()
+    df = pd.read_csv(csv_path)
+    assert len(df) == 1
+    assert list(df.columns) == ["MRN", "Date", "Failure Reason"]
+    assert df.loc[0, "MRN"] == "MRN999"
+    assert df.loc[0, "Date"] == "2025-02-20"
+    assert df.loc[0, "Failure Reason"] == "Failed to find images"
 
 
 def test_imageqr_cleans_up_getscu_temp(tmp_path):
@@ -874,7 +818,7 @@ def test_imageqr_cleans_up_getscu_temp_on_error(tmp_path):
         assert not getscu_temp.exists(), "getscu_temp should be removed even when pipeline raises"
 
 
-def test_imageqr_continues_despite_get_failures(tmp_path, capsys):
+def test_imageqr_continues_despite_get_failures(tmp_path, capsys, orthanc):
     """Test that imageqr job continues despite C-GET failures and zero file retrievals."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
@@ -885,77 +829,69 @@ def test_imageqr_continues_despite_get_failures(tmp_path, capsys):
     output_dir.mkdir()
     appdata_dir.mkdir()
 
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    # Upload 3 studies
+    for i in range(3):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "2.0")
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
 
-    try:
-        # Upload 3 studies
-        for i in range(3):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Smith^John{i}", "CT", "2.0")
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(3)]})
+    query_df.to_excel(query_file, index=False)
 
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({"AccessionNumber": [f"ACC{i:03d}" for i in range(3)]})
-        query_df.to_excel(query_file, index=False)
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
 
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
+    call_count = {"count": 0}
+
+    def mock_get_study(*args, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] == 1:
+            # First call: simulate zero files retrieved
+            return {
+                "success": True,
+                "num_completed": 0,
+                "num_failed": 0,
+                "num_warning": 0,
+                "message": "Get completed with no sub-operations"
+            }
+        elif call_count["count"] == 2:
+            # Second call: simulate exception
+            raise Exception("Network timeout during C-GET")
+        else:
+            # Third call: actually retrieve files
+            return get_study(*args, **kwargs)
+
+    with patch('utils.get_study', side_effect=mock_get_study):
+        result = imageqr(
+            pacs_list=[pacs_config],
+            query_spreadsheet=query_spreadsheet,
+            application_aet="TEST_AET",
+            output_dir=str(output_dir),
+            appdata_dir=str(appdata_dir)
         )
 
-        call_count = {"count": 0}
+    assert result is not None, "imageqr should return a result"
 
-        def mock_get_study(*args, **kwargs):
-            call_count["count"] += 1
-            if call_count["count"] == 1:
-                # First call: simulate zero files retrieved
-                return {
-                    "success": True,
-                    "num_completed": 0,
-                    "num_failed": 0,
-                    "num_warning": 0,
-                    "message": "Get completed with no sub-operations"
-                }
-            elif call_count["count"] == 2:
-                # Second call: simulate exception
-                raise Exception("Network timeout during C-GET")
-            else:
-                # Third call: actually retrieve files
-                return get_study(*args, **kwargs)
+    assert result["num_studies_found"] == 3, "Should have found 3 studies"
 
-        with patch('utils.get_study', side_effect=mock_get_study):
-            result = imageqr(
-                pacs_list=[pacs_config],
-                query_spreadsheet=query_spreadsheet,
-                application_aet="TEST_AET",
-                output_dir=str(output_dir),
-                appdata_dir=str(appdata_dir)
-            )
+    assert len(result["failed_query_indices"]) == 2, "Should have 2 failed queries"
+    assert 0 in result["failed_query_indices"], "First query should have failed (zero files)"
+    assert 1 in result["failed_query_indices"], "Second query should have failed (exception)"
 
-        assert result is not None, "imageqr should return a result"
+    captured = capsys.readouterr()
+    assert "0 files" in captured.out or "Exception while retrieving" in captured.out, "Should log failures"
 
-        assert result["num_studies_found"] == 3, "Should have found 3 studies"
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should exist"
 
-        assert len(result["failed_query_indices"]) == 2, "Should have 2 failed queries"
-        assert 0 in result["failed_query_indices"], "First query should have failed (zero files)"
-        assert 1 in result["failed_query_indices"], "Second query should have failed (exception)"
-
-        captured = capsys.readouterr()
-        assert "0 files" in captured.out or "Exception while retrieving" in captured.out, "Should log failures"
-
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should exist"
-
-        df = pd.read_csv(csv_path)
-        assert len(df) == 2, "Should have 2 failed queries in CSV"
-
-    finally:
-        orthanc.stop()
+    df = pd.read_csv(csv_path)
+    assert len(df) == 2, "Should have 2 failed queries in CSV"
 
 
 def test_generate_queries_and_filter_with_fallback(tmp_path):
@@ -1153,7 +1089,7 @@ def test_save_failed_queries_csv_with_fallback(tmp_path):
     assert df.loc[0, "Date"] == "2025-01-15"
 
 
-def test_imageqr_with_fallback_query(tmp_path):
+def test_imageqr_with_fallback_query(tmp_path, orthanc):
     """Integration test: imageqr with fallback recovers studies when accession doesn't match."""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
@@ -1164,57 +1100,49 @@ def test_imageqr_with_fallback_query(tmp_path):
     output_dir.mkdir()
     appdata_dir.mkdir()
 
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
+    # Upload study with accession ACC001
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
 
-    try:
-        # Upload study with accession ACC001
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
+    # Upload study with accession ACC002
+    ds = _create_test_dicom("ACC002", "MRN002", "Patient2", "CT", "3.0")
+    ds.InstanceNumber = 2
+    _upload_dicom_to_orthanc(ds, orthanc)
 
-        # Upload study with accession ACC002
-        ds = _create_test_dicom("ACC002", "MRN002", "Patient2", "CT", "3.0")
-        ds.InstanceNumber = 2
-        _upload_dicom_to_orthanc(ds, orthanc)
+    # Query with wrong accession for second study, but correct MRN+date
+    query_file = appdata_dir / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "WRONG_ACC"],
+        "PatientID": ["MRN001", "MRN002"],
+        "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
+    })
+    query_df.to_excel(query_file, index=False)
 
-        # Query with wrong accession for second study, but correct MRN+date
-        query_file = appdata_dir / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "WRONG_ACC"],
-            "PatientID": ["MRN001", "MRN002"],
-            "StudyDate": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")]
-        })
-        query_df.to_excel(query_file, index=False)
+    query_spreadsheet = Spreadsheet.from_file(
+        str(query_file),
+        acc_col="AccessionNumber",
+        mrn_col="PatientID",
+        date_col="StudyDate"
+    )
 
-        query_spreadsheet = Spreadsheet.from_file(
-            str(query_file),
-            acc_col="AccessionNumber",
-            mrn_col="PatientID",
-            date_col="StudyDate"
-        )
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
 
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
+    result = imageqr(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        use_fallback_query=True
+    )
 
-        result = imageqr(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            use_fallback_query=True
-        )
-
-        assert result["num_studies_found"] == 2, f"Should find 2 studies (1 by accession, 1 by fallback), found {result['num_studies_found']}"
-        assert result["num_images_saved"] == 2, f"Should save 2 images, saved {result['num_images_saved']}"
-
-    finally:
-        orthanc.stop()
+    assert result["num_studies_found"] == 2, f"Should find 2 studies (1 by accession, 1 by fallback), found {result['num_studies_found']}"
+    assert result["num_images_saved"] == 2, f"Should save 2 images, saved {result['num_images_saved']}"
 
 
 def test_imageqr_filter_with_fallback(tmp_path):

--- a/test_module_imageqr.py
+++ b/test_module_imageqr.py
@@ -162,7 +162,7 @@ def test_continuous_audit_log_saving(tmp_path):
         monitor_thread = threading.Thread(target=monitor_files, daemon=True)
         monitor_thread.start()
 
-        result = imageqr(
+        imageqr(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",

--- a/test_module_singleclickicore.py
+++ b/test_module_singleclickicore.py
@@ -283,8 +283,8 @@ def test_singleclickicore_with_text_deid_columns(tmp_path):
         project_name = "ColumnTest"
         
         from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
+
+        singleclickicore(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
@@ -524,8 +524,8 @@ def test_singleclickicore_skip_export_option(tmp_path):
         assert result["num_studies_found"] == 1
         assert result["num_images_exported"] == 1
         assert result["num_rows_processed"] == 1
-        assert result["export_performed"] == False
-        
+        assert not result["export_performed"]
+
         dcm_files = list(output_dir.rglob("*.dcm"))
         assert len(dcm_files) == 1, "Local DICOM file should exist"
         
@@ -598,7 +598,7 @@ def test_singleclickicore_export_enabled_by_default(tmp_path):
             apply_default_filter_script=False
         )
         
-        assert result["export_performed"] == True
+        assert result["export_performed"]
         
         blobs = azurite.list_blobs(container_name)
         dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
@@ -669,11 +669,11 @@ def test_singleclickicore_skip_export_no_sas_required(tmp_path):
         
         assert result["num_studies_found"] == 1
         assert result["num_images_exported"] == 1
-        assert result["export_performed"] == False
-        
+        assert not result["export_performed"]
+
         dcm_files = list(output_dir.rglob("*.dcm"))
         assert len(dcm_files) == 1
-        
+
         output_xlsx = output_dir / "output.xlsx"
         assert output_xlsx.exists()
     

--- a/test_module_singleclickicore.py
+++ b/test_module_singleclickicore.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import pandas as pd
-import pydicom
 import pytest
 
 from test_utils import _create_test_dicom, _upload_dicom_to_orthanc, AzuriteServer, OrthancServer

--- a/test_module_singleclickicore.py
+++ b/test_module_singleclickicore.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from test_utils import _create_test_dicom, _upload_dicom_to_orthanc, AzuriteServer, OrthancServer
+from test_utils import _create_test_dicom, _upload_dicom_to_orthanc
 from utils import PacsConfiguration, Spreadsheet
 from deid.grammar import generate_hipaa_safe_harbor_script
 from ctp import generate_sc_pdf_filter
@@ -38,330 +38,362 @@ def get_hipaa_test_config(user_filter_script=None):
     }
 
 
-def test_singleclickicore_basic_workflow(tmp_path):
+def test_singleclickicore_basic_workflow(tmp_path, orthanc, azurite):
     """Test basic workflow: image deid from PACS + text deid + export to Azure"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        # Upload test DICOMs to PACS
-        ds1 = _create_test_dicom("ACC001", "MRN001", "Patient One", "CT", "3.0")
-        ds1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        ds2 = _create_test_dicom("ACC002", "MRN002", "Patient Two", "CT", "3.0")
-        ds2.InstanceNumber = 2
-        _upload_dicom_to_orthanc(ds2, orthanc)
-        
-        time.sleep(2)
-        
-        # Create input Excel file with PHI in text columns
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "ACC002"],
-            "PatientName": ["John Smith was seen on January 5th, 2024", "Jane Doe at (555) 123-4567"],
-            "Notes": ["Contact john.smith@example.com", "MRN 1234567 on file"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
 
-        hipaa_config = get_hipaa_test_config()
+    # Upload test DICOMs to PACS
+    ds1 = _create_test_dicom("ACC001", "MRN001", "Patient One", "CT", "3.0")
+    ds1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds1, orthanc)
 
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "TestProject"
+    ds2 = _create_test_dicom("ACC002", "MRN002", "Patient Two", "CT", "3.0")
+    ds2.InstanceNumber = 2
+    _upload_dicom_to_orthanc(ds2, orthanc)
 
-        from module_singleclickicore import singleclickicore
+    time.sleep(2)
 
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=hipaa_config['anonymizer_script'],
-            filter_script=hipaa_config['filter_script'],
-            deid_pixels=hipaa_config['deid_pixels'],
-            apply_default_filter_script=hipaa_config['apply_default_filter_script'],
-        )
-        
-        # Verify image deid results
-        assert result["num_studies_found"] == 2
-        assert result["num_images_exported"] == 2
-        
-        # Verify text deid was run
-        assert result["num_rows_processed"] == 2
-        
-        # Verify output files exist locally
-        dcm_files_in_output = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files_in_output) == 2, "Deidentified DICOM files should be in output_dir"
-        
-        output_xlsx = output_dir / "output.xlsx"
-        assert output_xlsx.exists(), "Deidentified Excel should be in output_dir"
-        
-        # Verify text deid removed PHI from Excel
-        result_df = pd.read_excel(output_xlsx)
-        all_text = str(result_df.to_dict())
-        assert "Smith" not in all_text, "PatientName PHI should be removed"
-        assert "(555) 123-4567" not in all_text, "Phone should be removed"
-        assert "john.smith@example.com" not in all_text, "Email should be removed"
-        assert "1234567" not in all_text, "MRN should be removed"
-        # Verify redaction markers are present
-        assert "[PERSONALNAME]" in all_text or "[ALPHANUMERICID]" in all_text, "Should have redaction markers"
-        
-        # Verify blobs were uploaded to Azure
-        blobs = azurite.list_blobs(container_name)
-        # Should have 2 DICOM files + 1 Excel file
-        dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
-        xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
-        assert len(dcm_blobs) == 2, "2 DICOM files should be uploaded"
-        assert len(xlsx_blobs) == 1, "1 Excel file should be uploaded"
-        
-        # Verify all blobs are under project name
-        for blob in blobs:
-            assert blob.startswith(f"{project_name}/"), f"Blob {blob} should be under project folder"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+    # Create input Excel file with PHI in text columns
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "ACC002"],
+        "PatientName": ["John Smith was seen on January 5th, 2024", "Jane Doe at (555) 123-4567"],
+        "Notes": ["Contact john.smith@example.com", "MRN 1234567 on file"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    hipaa_config = get_hipaa_test_config()
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "TestProject"
+
+    from module_singleclickicore import singleclickicore
+
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=hipaa_config['anonymizer_script'],
+        filter_script=hipaa_config['filter_script'],
+        deid_pixels=hipaa_config['deid_pixels'],
+        apply_default_filter_script=hipaa_config['apply_default_filter_script'],
+    )
+
+    # Verify image deid results
+    assert result["num_studies_found"] == 2
+    assert result["num_images_exported"] == 2
+
+    # Verify text deid was run
+    assert result["num_rows_processed"] == 2
+
+    # Verify output files exist locally
+    dcm_files_in_output = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files_in_output) == 2, "Deidentified DICOM files should be in output_dir"
+
+    output_xlsx = output_dir / "output.xlsx"
+    assert output_xlsx.exists(), "Deidentified Excel should be in output_dir"
+
+    # Verify text deid removed PHI from Excel
+    result_df = pd.read_excel(output_xlsx)
+    all_text = str(result_df.to_dict())
+    assert "Smith" not in all_text, "PatientName PHI should be removed"
+    assert "(555) 123-4567" not in all_text, "Phone should be removed"
+    assert "john.smith@example.com" not in all_text, "Email should be removed"
+    assert "1234567" not in all_text, "MRN should be removed"
+    # Verify redaction markers are present
+    assert "[PERSONALNAME]" in all_text or "[ALPHANUMERICID]" in all_text, "Should have redaction markers"
+
+    # Verify blobs were uploaded to Azure
+    blobs = azurite.list_blobs(container_name)
+    # Should have 2 DICOM files + 1 Excel file
+    dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
+    xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
+    assert len(dcm_blobs) == 2, "2 DICOM files should be uploaded"
+    assert len(xlsx_blobs) == 1, "1 Excel file should be uploaded"
+
+    # Verify all blobs are under project name
+    for blob in blobs:
+        assert blob.startswith(f"{project_name}/"), f"Blob {blob} should be under project folder"
 
 
-def test_singleclickicore_with_filter_script(tmp_path):
+def test_singleclickicore_with_filter_script(tmp_path, orthanc, azurite):
     """Test that filter scripts work for image deid"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        # Upload DICOMs with different slice thicknesses
-        for i, slice_thickness in enumerate(["0.5", "3.0", "5.0"]):
-            ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", slice_thickness)
-            ds.InstanceNumber = i + 1
-            _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC000", "ACC001", "ACC002"],
-            "Notes": ["Test note 1", "Test note 2", "Test note 3"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    # Upload DICOMs with different slice thicknesses
+    for i, slice_thickness in enumerate(["0.5", "3.0", "5.0"]):
+        ds = _create_test_dicom(f"ACC{i:03d}", f"MRN{i:04d}", f"Patient{i}", "CT", slice_thickness)
+        ds.InstanceNumber = i + 1
+        _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC000", "ACC001", "ACC002"],
+        "Notes": ["Test note 1", "Test note 2", "Test note 3"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        # Filter to only accept slice thickness between 1 and 5
-        filter_script = 'SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "FilteredProject"
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=anonymizer_script,
-            filter_script=filter_script,
-            apply_default_filter_script=False
-        )
-        
-        # Only 1 image should pass filter (3.0 slice thickness)
-        assert result["num_studies_found"] == 3
-        assert result["num_images_exported"] == 1
-        assert result["num_images_quarantined"] == 2
-        
-        # Text deid should still process all rows
-        assert result["num_rows_processed"] == 3
-        
-        blobs = azurite.list_blobs(container_name)
-        dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
-        assert len(dcm_blobs) == 1, "Only 1 filtered DICOM should be exported"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+
+    # Filter to only accept slice thickness between 1 and 5
+    filter_script = 'SliceThickness.isGreaterThan("1") * SliceThickness.isLessThan("5")'
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "FilteredProject"
+
+    from module_singleclickicore import singleclickicore
+
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        filter_script=filter_script,
+        apply_default_filter_script=False
+    )
+
+    # Only 1 image should pass filter (3.0 slice thickness)
+    assert result["num_studies_found"] == 3
+    assert result["num_images_exported"] == 1
+    assert result["num_images_quarantined"] == 2
+
+    # Text deid should still process all rows
+    assert result["num_rows_processed"] == 3
+
+    blobs = azurite.list_blobs(container_name)
+    dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
+    assert len(dcm_blobs) == 1, "Only 1 filtered DICOM should be exported"
 
 
-def test_singleclickicore_with_text_deid_columns(tmp_path):
+def test_singleclickicore_with_text_deid_columns(tmp_path, orthanc, azurite):
     """Test that columns_to_deid and columns_to_drop work"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001"],
-            "SensitiveColumn": ["This has John Smith PHI"],
-            "DropMe": ["Should be dropped"],
-            "KeepAsIs": ["No PHI here, keep unchanged"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001"],
+        "SensitiveColumn": ["This has John Smith PHI"],
+        "DropMe": ["Should be dropped"],
+        "KeepAsIs": ["No PHI here, keep unchanged"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "ColumnTest"
-        
-        from module_singleclickicore import singleclickicore
 
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "ColumnTest"
+
+    from module_singleclickicore import singleclickicore
+
+    singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        columns_to_deid=["SensitiveColumn"],
+        columns_to_drop=["DropMe"],
+        apply_default_filter_script=False
+    )
+
+    output_xlsx = output_dir / "output.xlsx"
+    result_df = pd.read_excel(output_xlsx)
+
+    # DropMe column should be removed
+    assert "DropMe" not in result_df.columns
+
+    # KeepAsIs should be unchanged
+    assert "KeepAsIs" in result_df.columns
+    assert result_df.loc[0, "KeepAsIs"] == "No PHI here, keep unchanged"
+
+    # SensitiveColumn should be deidentified - Smith should be removed
+    assert "Smith" not in str(result_df["SensitiveColumn"].tolist())
+
+
+def test_singleclickicore_handles_pacs_failures(tmp_path, azurite):
+    """Test that PACS failures are handled gracefully"""
+    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
+    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
+
+    appdata_dir = tmp_path / "appdata"
+    appdata_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "ACC002"],
+        "Notes": ["Note 1", "Note 2"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    # Invalid PACS config - will fail to connect
+    invalid_pacs_config = PacsConfiguration(
+        host="invalid-host.local",
+        port=99999,
+        aet="INVALID"
+    )
+
+    anonymizer_script = """<script>
+<e en="T" t="00100010" n="PatientName">@empty()</e>
+</script>"""
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "FailedProject"
+
+    from module_singleclickicore import singleclickicore
+
+    result = singleclickicore(
+        pacs_list=[invalid_pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    # PACS queries should fail
+    assert result["num_studies_found"] == 0
+    assert result["num_images_exported"] == 0
+    assert len(result["failed_query_indices"]) == 2
+
+    # But text deid should still complete
+    assert result["num_rows_processed"] == 2
+
+    output_xlsx = output_dir / "output.xlsx"
+    assert output_xlsx.exists(), "Text deid should still produce output"
+
+    # Export should still work for the text file
+    blobs = azurite.list_blobs(container_name)
+    xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
+    assert len(xlsx_blobs) == 1, "Excel file should still be exported"
+
+
+def test_singleclickicore_handles_export_failures(tmp_path, orthanc):
+    """Test that export failures raise appropriate errors"""
+    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
+    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
+
+    appdata_dir = tmp_path / "appdata"
+    appdata_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001"],
+        "Notes": ["Test note"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
+<e en="T" t="00100010" n="PatientName">@empty()</e>
+</script>"""
+
+    # Invalid SAS URL - export will fail
+    invalid_sas_url = "http://invalid-storage.blob.core.windows.net/container?invalidtoken"
+    project_name = "ExportFail"
+
+    from module_singleclickicore import singleclickicore
+
+    with pytest.raises(Exception) as exc_info:
         singleclickicore(
             pacs_list=[pacs_config],
             query_spreadsheet=query_spreadsheet,
             application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=anonymizer_script,
-            columns_to_deid=["SensitiveColumn"],
-            columns_to_drop=["DropMe"],
-            apply_default_filter_script=False
-        )
-        
-        output_xlsx = output_dir / "output.xlsx"
-        result_df = pd.read_excel(output_xlsx)
-        
-        # DropMe column should be removed
-        assert "DropMe" not in result_df.columns
-        
-        # KeepAsIs should be unchanged
-        assert "KeepAsIs" in result_df.columns
-        assert result_df.loc[0, "KeepAsIs"] == "No PHI here, keep unchanged"
-        
-        # SensitiveColumn should be deidentified - Smith should be removed
-        assert "Smith" not in str(result_df["SensitiveColumn"].tolist())
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
-
-
-def test_singleclickicore_handles_pacs_failures(tmp_path):
-    """Test that PACS failures are handled gracefully"""
-    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
-    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
-    appdata_dir = tmp_path / "appdata"
-    appdata_dir.mkdir()
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "ACC002"],
-            "Notes": ["Note 1", "Note 2"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        # Invalid PACS config - will fail to connect
-        invalid_pacs_config = PacsConfiguration(
-            host="invalid-host.local",
-            port=99999,
-            aet="INVALID"
-        )
-        
-        anonymizer_script = """<script>
-<e en="T" t="00100010" n="PatientName">@empty()</e>
-</script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "FailedProject"
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[invalid_pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
+            sas_url=invalid_sas_url,
             project_name=project_name,
             output_dir=str(output_dir),
             appdata_dir=str(appdata_dir),
@@ -369,386 +401,265 @@ def test_singleclickicore_handles_pacs_failures(tmp_path):
             anonymizer_script=anonymizer_script,
             apply_default_filter_script=False
         )
-        
-        # PACS queries should fail
-        assert result["num_studies_found"] == 0
-        assert result["num_images_exported"] == 0
-        assert len(result["failed_query_indices"]) == 2
-        
-        # But text deid should still complete
-        assert result["num_rows_processed"] == 2
-        
-        output_xlsx = output_dir / "output.xlsx"
-        assert output_xlsx.exists(), "Text deid should still produce output"
-        
-        # Export should still work for the text file
-        blobs = azurite.list_blobs(container_name)
-        xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
-        assert len(xlsx_blobs) == 1, "Excel file should still be exported"
-    
-    finally:
-        azurite.stop()
+
+    # Should raise an rclone error
+    error_msg = str(exc_info.value).lower()
+    assert "rclone" in error_msg or "error" in error_msg
+
+    # But local files should still exist
+    dcm_files = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files) == 1, "Local DICOM file should still exist"
+
+    output_xlsx = output_dir / "output.xlsx"
+    assert output_xlsx.exists(), "Local Excel file should still exist"
 
 
-def test_singleclickicore_handles_export_failures(tmp_path):
-    """Test that export failures raise appropriate errors"""
-    os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
-    os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
-    appdata_dir = tmp_path / "appdata"
-    appdata_dir.mkdir()
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001"],
-            "Notes": ["Test note"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
-<e en="T" t="00100010" n="PatientName">@empty()</e>
-</script>"""
-        
-        # Invalid SAS URL - export will fail
-        invalid_sas_url = "http://invalid-storage.blob.core.windows.net/container?invalidtoken"
-        project_name = "ExportFail"
-        
-        from module_singleclickicore import singleclickicore
-        
-        with pytest.raises(Exception) as exc_info:
-            singleclickicore(
-                pacs_list=[pacs_config],
-                query_spreadsheet=query_spreadsheet,
-                application_aet="TEST_AET",
-                sas_url=invalid_sas_url,
-                project_name=project_name,
-                output_dir=str(output_dir),
-                appdata_dir=str(appdata_dir),
-                input_file=str(query_file),
-                anonymizer_script=anonymizer_script,
-                apply_default_filter_script=False
-            )
-        
-        # Should raise an rclone error
-        error_msg = str(exc_info.value).lower()
-        assert "rclone" in error_msg or "error" in error_msg
-        
-        # But local files should still exist
-        dcm_files = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files) == 1, "Local DICOM file should still exist"
-        
-        output_xlsx = output_dir / "output.xlsx"
-        assert output_xlsx.exists(), "Local Excel file should still exist"
-    
-    finally:
-        orthanc.stop()
-
-
-def test_singleclickicore_skip_export_option(tmp_path):
+def test_singleclickicore_skip_export_option(tmp_path, orthanc):
     """Test that skip_export=True prevents Azure upload but preserves local files"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001"],
-            "Notes": ["Test note"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001"],
+        "Notes": ["Test note"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url="",
-            project_name="TestProject",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False,
-            skip_export=True
-        )
-        
-        assert result["num_studies_found"] == 1
-        assert result["num_images_exported"] == 1
-        assert result["num_rows_processed"] == 1
-        assert not result["export_performed"]
 
-        dcm_files = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files) == 1, "Local DICOM file should exist"
-        
-        output_xlsx = output_dir / "output.xlsx"
-        assert output_xlsx.exists(), "Local Excel file should exist"
-    
-    finally:
-        orthanc.stop()
+    from module_singleclickicore import singleclickicore
+
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url="",
+        project_name="TestProject",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False,
+        skip_export=True
+    )
+
+    assert result["num_studies_found"] == 1
+    assert result["num_images_exported"] == 1
+    assert result["num_rows_processed"] == 1
+    assert not result["export_performed"]
+
+    dcm_files = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files) == 1, "Local DICOM file should exist"
+
+    output_xlsx = output_dir / "output.xlsx"
+    assert output_xlsx.exists(), "Local Excel file should exist"
 
 
-def test_singleclickicore_export_enabled_by_default(tmp_path):
+def test_singleclickicore_export_enabled_by_default(tmp_path, orthanc, azurite):
     """Test that export happens by default when skip_export is not specified"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    azurite = AzuriteServer()
-    azurite.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001"],
-            "Notes": ["Test note"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001"],
+        "Notes": ["Test note"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        container_name = "testcontainer"
-        sas_url = azurite.get_sas_url(container_name)
-        project_name = "DefaultExportProject"
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=sas_url,
-            project_name=project_name,
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False
-        )
-        
-        assert result["export_performed"]
-        
-        blobs = azurite.list_blobs(container_name)
-        dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
-        xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
-        assert len(dcm_blobs) == 1, "DICOM should be uploaded to Azure"
-        assert len(xlsx_blobs) == 1, "Excel should be uploaded to Azure"
-    
-    finally:
-        orthanc.stop()
-        azurite.stop()
+
+    container_name = "testcontainer"
+    sas_url = azurite.get_sas_url(container_name)
+    project_name = "DefaultExportProject"
+
+    from module_singleclickicore import singleclickicore
+
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=sas_url,
+        project_name=project_name,
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False
+    )
+
+    assert result["export_performed"]
+
+    blobs = azurite.list_blobs(container_name)
+    dcm_blobs = [b for b in blobs if b.endswith('.dcm')]
+    xlsx_blobs = [b for b in blobs if b.endswith('.xlsx')]
+    assert len(dcm_blobs) == 1, "DICOM should be uploaded to Azure"
+    assert len(xlsx_blobs) == 1, "Excel should be uploaded to Azure"
 
 
-def test_singleclickicore_skip_export_no_sas_required(tmp_path):
+def test_singleclickicore_skip_export_no_sas_required(tmp_path, orthanc):
     """Test that SAS URL is not required when skip_export=True"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds, orthanc)
-        
-        time.sleep(2)
-        
-        query_file = appdata_dir / "input.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001"],
-            "Notes": ["Test note"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds, orthanc)
+
+    time.sleep(2)
+
+    query_file = appdata_dir / "input.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001"],
+        "Notes": ["Test note"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    query_spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 </script>"""
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=query_spreadsheet,
-            application_aet="TEST_AET",
-            sas_url=None,
-            project_name="NoSASProject",
-            output_dir=str(output_dir),
-            appdata_dir=str(appdata_dir),
-            input_file=str(query_file),
-            anonymizer_script=anonymizer_script,
-            apply_default_filter_script=False,
-            skip_export=True
-        )
-        
-        assert result["num_studies_found"] == 1
-        assert result["num_images_exported"] == 1
-        assert not result["export_performed"]
 
-        dcm_files = list(output_dir.rglob("*.dcm"))
-        assert len(dcm_files) == 1
+    from module_singleclickicore import singleclickicore
 
-        output_xlsx = output_dir / "output.xlsx"
-        assert output_xlsx.exists()
-    
-    finally:
-        orthanc.stop()
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=query_spreadsheet,
+        application_aet="TEST_AET",
+        sas_url=None,
+        project_name="NoSASProject",
+        output_dir=str(output_dir),
+        appdata_dir=str(appdata_dir),
+        input_file=str(query_file),
+        anonymizer_script=anonymizer_script,
+        apply_default_filter_script=False,
+        skip_export=True
+    )
+
+    assert result["num_studies_found"] == 1
+    assert result["num_images_exported"] == 1
+    assert not result["export_performed"]
+
+    dcm_files = list(output_dir.rglob("*.dcm"))
+    assert len(dcm_files) == 1
+
+    output_xlsx = output_dir / "output.xlsx"
+    assert output_xlsx.exists()
 
 
-def test_singleclickicore_saves_failed_queries_csv(tmp_path):
+def test_singleclickicore_saves_failed_queries_csv(tmp_path, orthanc):
     """Test that failed_queries.csv is created via imagedeid_pacs"""
     os.environ['JAVA_HOME'] = str(Path(__file__).parent / "jre8" / "Contents" / "Home")
     os.environ['DCMTK_HOME'] = str(Path(__file__).parent / "dcmtk")
-    
+
     appdata_dir = tmp_path / "appdata"
     appdata_dir.mkdir()
     output_dir = tmp_path / "output"
     output_dir.mkdir()
-    
-    orthanc = OrthancServer()
-    orthanc.add_modality("TEST_AET", "TEST_AET", "host.docker.internal", 50001)
-    orthanc.start()
-    
-    try:
-        ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
-        ds1.InstanceNumber = 1
-        _upload_dicom_to_orthanc(ds1, orthanc)
-        
-        time.sleep(2)
-        
-        input_file = appdata_dir / "input.xlsx"
-        input_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "ACC999"],
-            "PatientName": ["Test Patient", "Missing Patient"]
-        })
-        input_df.to_excel(input_file, index=False)
-        
-        pacs_config = PacsConfiguration(
-            host="localhost",
-            port=orthanc.dicom_port,
-            aet=orthanc.aet
-        )
-        
-        anonymizer_script = """<script>
+
+    ds1 = _create_test_dicom("ACC001", "MRN001", "Patient1", "CT", "3.0")
+    ds1.InstanceNumber = 1
+    _upload_dicom_to_orthanc(ds1, orthanc)
+
+    time.sleep(2)
+
+    input_file = appdata_dir / "input.xlsx"
+    input_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "ACC999"],
+        "PatientName": ["Test Patient", "Missing Patient"]
+    })
+    input_df.to_excel(input_file, index=False)
+
+    pacs_config = PacsConfiguration(
+        host="localhost",
+        port=orthanc.dicom_port,
+        aet=orthanc.aet
+    )
+
+    anonymizer_script = """<script>
 <e en="T" t="00100010" n="PatientName">@empty()</e>
 <e en="T" t="00100020" n="PatientID">@empty()</e>
 </script>"""
-        
-        from module_singleclickicore import singleclickicore
-        
-        result = singleclickicore(
-            pacs_list=[pacs_config],
-            query_spreadsheet=Spreadsheet.from_file(str(input_file), acc_col="AccessionNumber"),
-            application_aet="TEST_AET",
-            sas_url="https://dummy.blob.core.windows.net/container?sas",
-            project_name="TestProject",
-            output_dir=str(output_dir),
-            input_file=str(input_file),
-            appdata_dir=str(appdata_dir),
-            anonymizer_script=anonymizer_script,
-            columns_to_drop=["PatientName"],
-            apply_default_filter_script=False,
-            skip_export=True
-        )
-        
-        assert result["num_studies_found"] == 1
-        assert len(result["failed_query_indices"]) == 1
-        
-        csv_path = appdata_dir / "failed_queries.csv"
-        assert csv_path.exists(), "failed_queries.csv should be created by imagedeid_pacs"
-        
-        df = pd.read_csv(csv_path)
-        assert len(df) == 1
-        assert df.loc[0, "Accession Number"] == "ACC999"
-        assert df.loc[0, "Failure Reason"] == "Failed to find images"
-    
-    finally:
-        orthanc.stop()
 
+    from module_singleclickicore import singleclickicore
 
+    result = singleclickicore(
+        pacs_list=[pacs_config],
+        query_spreadsheet=Spreadsheet.from_file(str(input_file), acc_col="AccessionNumber"),
+        application_aet="TEST_AET",
+        sas_url="https://dummy.blob.core.windows.net/container?sas",
+        project_name="TestProject",
+        output_dir=str(output_dir),
+        input_file=str(input_file),
+        appdata_dir=str(appdata_dir),
+        anonymizer_script=anonymizer_script,
+        columns_to_drop=["PatientName"],
+        apply_default_filter_script=False,
+        skip_export=True
+    )
+
+    assert result["num_studies_found"] == 1
+    assert len(result["failed_query_indices"]) == 1
+
+    csv_path = appdata_dir / "failed_queries.csv"
+    assert csv_path.exists(), "failed_queries.csv should be created by imagedeid_pacs"
+
+    df = pd.read_csv(csv_path)
+    assert len(df) == 1
+    assert df.loc[0, "Accession Number"] == "ACC999"
+    assert df.loc[0, "Failure Reason"] == "Failed to find images"

--- a/test_module_textdeid.py
+++ b/test_module_textdeid.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import pytest
 import pandas as pd
 from module_textdeid import textdeid
 

--- a/test_utils.py
+++ b/test_utils.py
@@ -8,47 +8,11 @@ import uuid
 
 import numpy as np
 import pandas as pd
-import pytest
 import requests
 from pydicom.dataset import FileDataset, FileMetaDataset, Dataset
 from pydicom.uid import generate_uid, SecondaryCaptureImageStorage, ExplicitVRLittleEndian, PYDICOM_IMPLEMENTATION_UID, EncapsulatedPDFStorage, UID
 
 from utils import csv_string_to_xlsx, Spreadsheet, generate_queries_and_filter, save_failed_queries_csv, find_studies_from_pacs_list, get_studies_from_study_pacs_map, PacsConfiguration
-
-
-def _cleanup_test_containers():
-    result = subprocess.run(
-        ["docker", "ps", "-a", "--filter", "name=orthanc_test_", "--format", "{{.Names}}"],
-        capture_output=True,
-        text=True
-    )
-    
-    container_names = result.stdout.strip().split('\n')
-    container_names = [name for name in container_names if name]
-    
-    for container_name in container_names:
-        subprocess.run(["docker", "stop", container_name], capture_output=True)
-        subprocess.run(["docker", "rm", container_name], capture_output=True)
-    
-    result = subprocess.run(
-        ["docker", "ps", "-a", "--filter", "name=azurite_test_", "--format", "{{.Names}}"],
-        capture_output=True,
-        text=True
-    )
-    
-    container_names = result.stdout.strip().split('\n')
-    container_names = [name for name in container_names if name]
-    
-    for container_name in container_names:
-        subprocess.run(["docker", "stop", container_name], capture_output=True)
-        subprocess.run(["docker", "rm", container_name], capture_output=True)
-
-
-@pytest.fixture(scope="function", autouse=True)
-def cleanup_docker_containers():
-    _cleanup_test_containers()
-    yield
-    _cleanup_test_containers()
 
 
 def _create_test_dicom(accession, patient_id, patient_name, modality, slice_thickness):
@@ -522,6 +486,12 @@ class OrthancServer:
         response = requests.get(f"{self.base_url}/studies")
         return len(response.json())
     
+    def clear_data(self):
+        """Delete all patients (and their studies/series/instances) from Orthanc."""
+        response = requests.get(f"{self.base_url}/patients")
+        for patient_id in response.json():
+            requests.delete(f"{self.base_url}/patients/{patient_id}")
+
     def get_pacs_config(self):
         """Get a PacsConfiguration object for this Orthanc instance."""
         from utils import PacsConfiguration
@@ -639,6 +609,14 @@ class AzuriteServer:
         
         return blob_client.download_blob().readall()
     
+    def clear_data(self):
+        """Delete all containers in the Azurite storage account."""
+        from azure.storage.blob import BlobServiceClient
+
+        client = BlobServiceClient.from_connection_string(self.connection_string)
+        for container in client.list_containers():
+            client.delete_container(container['name'])
+
     def stop(self):
         """Stop and remove the Azurite Docker container"""
         if self.container:
@@ -853,41 +831,34 @@ def test_save_failed_queries_csv_empty_failures(tmp_path):
     assert list(df.columns) == ["Accession Number", "Failure Reason"]
 
 
-def test_find_studies_returns_failure_details(tmp_path):
-    orthanc = OrthancServer(aet="ORTHANC")
-    try:
-        orthanc.start()
-        
-        orthanc.upload_study(
-            patient_id="MRN001",
-            accession="ACC001",
-            study_date="20250115"
-        )
-        
-        query_file = tmp_path / "query.xlsx"
-        query_df = pd.DataFrame({
-            "AccessionNumber": ["ACC001", "ACC999"]
-        })
-        query_df.to_excel(query_file, index=False)
-        
-        spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
-        query_params_list, expected_values_list, _ = generate_queries_and_filter(spreadsheet)
-        
-        pacs_list = [PacsConfiguration(host="localhost", port=orthanc.dicom_port, aet=orthanc.aet)]
-        application_aet = "TEST_AET"
-        
-        study_pacs_map, failed_query_indices, failure_details = find_studies_from_pacs_list(
-            pacs_list, query_params_list, application_aet, expected_values_list
-        )
-        
-        assert len(study_pacs_map) == 1
-        assert len(failed_query_indices) == 1
-        assert 1 in failed_query_indices
-        assert 1 in failure_details
-        assert failure_details[1] == "Failed to find images"
-        
-    finally:
-        orthanc.stop()
+def test_find_studies_returns_failure_details(tmp_path, orthanc):
+    orthanc.upload_study(
+        patient_id="MRN001",
+        accession="ACC001",
+        study_date="20250115"
+    )
+
+    query_file = tmp_path / "query.xlsx"
+    query_df = pd.DataFrame({
+        "AccessionNumber": ["ACC001", "ACC999"]
+    })
+    query_df.to_excel(query_file, index=False)
+
+    spreadsheet = Spreadsheet.from_file(str(query_file), acc_col="AccessionNumber")
+    query_params_list, expected_values_list, _ = generate_queries_and_filter(spreadsheet)
+
+    pacs_list = [PacsConfiguration(host="localhost", port=orthanc.dicom_port, aet=orthanc.aet)]
+    application_aet = "TEST_AET"
+
+    study_pacs_map, failed_query_indices, failure_details = find_studies_from_pacs_list(
+        pacs_list, query_params_list, application_aet, expected_values_list
+    )
+
+    assert len(study_pacs_map) == 1
+    assert len(failed_query_indices) == 1
+    assert 1 in failed_query_indices
+    assert 1 in failure_details
+    assert failure_details[1] == "Failed to find images"
 
 
 def test_get_studies_returns_failure_details(tmp_path):

--- a/test_utils.py
+++ b/test_utils.py
@@ -9,7 +9,6 @@ import uuid
 import numpy as np
 import pandas as pd
 import pytest
-import pydicom
 import requests
 from pydicom.dataset import FileDataset, FileMetaDataset, Dataset
 from pydicom.uid import generate_uid, SecondaryCaptureImageStorage, ExplicitVRLittleEndian, PYDICOM_IMPLEMENTATION_UID, EncapsulatedPDFStorage, UID
@@ -893,7 +892,7 @@ def test_find_studies_returns_failure_details(tmp_path):
 
 def test_get_studies_returns_failure_details(tmp_path):
     """Test that get_studies_from_study_pacs_map returns failure details as 3rd value"""
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
 
     pacs = PacsConfiguration(host="localhost", port=4242, aet="TEST_PACS")
     study_pacs_map = {

--- a/test_utils.py
+++ b/test_utils.py
@@ -368,12 +368,12 @@ class Fixtures:
                             accession="ACC001", study_date="20240101", 
                             modality="CT", **extra_tags):
         file_meta = FileMetaDataset()
-        file_meta.MediaStorageSOPClassUID = '1.2.840.10008.5.1.4.1.1.2'
+        file_meta.MediaStorageSOPClassUID = pydicom.uid.UID('1.2.840.10008.5.1.4.1.1.2')
         file_meta.MediaStorageSOPInstanceUID = generate_uid()
-        file_meta.TransferSyntaxUID = '1.2.840.10008.1.2.1'
+        file_meta.TransferSyntaxUID = pydicom.uid.UID('1.2.840.10008.1.2.1')
         file_meta.ImplementationClassUID = generate_uid()
         
-        ds = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
+        ds = FileDataset("", {}, file_meta=file_meta, preamble=b"\0" * 128)
         
         ds.PatientName = patient_name
         ds.PatientID = patient_id

--- a/test_utils.py
+++ b/test_utils.py
@@ -382,14 +382,33 @@ class OrthancServer:
     def add_modality(self, name, aet, ip, port):
         self.modalities[name] = [aet, ip, port]
     
+    _shared_network = "orthanc_test_shared_net"
+
+    @classmethod
+    def _ensure_shared_network(cls):
+        # Check if network already exists (fast path, no error on missing)
+        result = subprocess.run(
+            ["docker", "network", "inspect", cls._shared_network],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return
+        # Create the network; another xdist worker may race us, so ignore "already exists"
+        result = subprocess.run(
+            ["docker", "network", "create", cls._shared_network],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0 and "already exists" not in result.stderr:
+            raise RuntimeError(
+                f"Failed to create Docker network '{cls._shared_network}': {result.stderr.strip()}"
+            )
+
     def start(self):
         container_name = f"orthanc_test_{uuid.uuid4().hex[:8]}"
-        network_name = f"orthanc_net_{uuid.uuid4().hex[:8]}"
 
-        # Create Docker network for C-GET support
-        subprocess.run(["docker", "network", "create", network_name],
-                      check=True, capture_output=True)
-        self.network = network_name
+        # Reuse a single Docker network across all test OrthancServer instances
+        self._ensure_shared_network()
+        self.network = None  # not owned by this instance
 
         self.config_dir = tempfile.mkdtemp()
         self.storage_dir = tempfile.mkdtemp()
@@ -417,7 +436,7 @@ class OrthancServer:
         subprocess.run([
             "docker", "run", "-d",
             "--name", container_name,
-            "--network", network_name,
+            "--network", self._shared_network,
             "-p", f"{self.http_port}:8042",
             "-p", f"{self.dicom_port}:4242",
             "-v", f"{self.config_dir}:/etc/orthanc:ro",
@@ -506,8 +525,6 @@ class OrthancServer:
             subprocess.run(["docker", "stop", self.container], capture_output=True, timeout=10)
             subprocess.run(["docker", "rm", self.container], capture_output=True, timeout=10)
             time.sleep(0.5)  # Brief wait to ensure cleanup completes
-        if self.network:
-            subprocess.run(["docker", "network", "rm", self.network], capture_output=True, timeout=10)
 
 
 class AzuriteServer:

--- a/test_utils.py
+++ b/test_utils.py
@@ -468,7 +468,7 @@ class OrthancServer:
                 response = requests.get(f"{self.base_url}/system", timeout=1)
                 if response.status_code == 200:
                     break
-            except:
+            except Exception:
                 pass
             time.sleep(1)
         else:

--- a/test_utils.py
+++ b/test_utils.py
@@ -12,7 +12,7 @@ import pytest
 import pydicom
 import requests
 from pydicom.dataset import FileDataset, FileMetaDataset, Dataset
-from pydicom.uid import generate_uid, SecondaryCaptureImageStorage, ExplicitVRLittleEndian, PYDICOM_IMPLEMENTATION_UID, EncapsulatedPDFStorage
+from pydicom.uid import generate_uid, SecondaryCaptureImageStorage, ExplicitVRLittleEndian, PYDICOM_IMPLEMENTATION_UID, EncapsulatedPDFStorage, UID
 
 from utils import csv_string_to_xlsx, Spreadsheet, generate_queries_and_filter, save_failed_queries_csv, find_studies_from_pacs_list, get_studies_from_study_pacs_map, PacsConfiguration
 
@@ -79,10 +79,9 @@ def _create_test_dicom(accession, patient_id, patient_name, modality, slice_thic
 
 
 def _upload_dicom_to_orthanc(ds, orthanc):
-    temp_file = tempfile.mktemp(suffix=".dcm")
-    ds.save_as(temp_file)
-    orthanc.upload_dicom(temp_file)
-    os.remove(temp_file)
+    with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+        ds.save_as(tmp.name)
+        orthanc.upload_dicom(tmp.name)
     # Give time for the DICOM to be uploaded to Orthanc
     time.sleep(2)
 
@@ -368,9 +367,9 @@ class Fixtures:
                             accession="ACC001", study_date="20240101", 
                             modality="CT", **extra_tags):
         file_meta = FileMetaDataset()
-        file_meta.MediaStorageSOPClassUID = pydicom.uid.UID('1.2.840.10008.5.1.4.1.1.2')
+        file_meta.MediaStorageSOPClassUID = UID('1.2.840.10008.5.1.4.1.1.2')
         file_meta.MediaStorageSOPInstanceUID = generate_uid()
-        file_meta.TransferSyntaxUID = pydicom.uid.UID('1.2.840.10008.1.2.1')
+        file_meta.TransferSyntaxUID = UID('1.2.840.10008.1.2.1')
         file_meta.ImplementationClassUID = generate_uid()
         
         ds = FileDataset("", {}, file_meta=file_meta, preamble=b"\0" * 128)
@@ -516,10 +515,9 @@ class OrthancServer:
                 if series_date:
                     ds.SeriesDate = series_date
                 
-                temp_file = tempfile.mktemp(suffix=".dcm")
-                ds.save_as(temp_file)
-                self.upload_dicom(temp_file)
-                os.remove(temp_file)
+                with tempfile.NamedTemporaryFile(suffix=".dcm") as tmp:
+                    ds.save_as(tmp.name)
+                    self.upload_dicom(tmp.name)
     
     def get_study_count(self):
         response = requests.get(f"{self.base_url}/studies")
@@ -600,7 +598,7 @@ class AzuriteServer:
     def get_sas_url(self, container_name):
         """Generate a SAS URL for a container"""
         from azure.storage.blob import BlobServiceClient, generate_container_sas, ContainerSasPermissions
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         
         # Create container if it doesn't exist
         client = BlobServiceClient.from_connection_string(self.connection_string)
@@ -615,7 +613,7 @@ class AzuriteServer:
             container_name=container_name,
             account_key=self.account_key,
             permission=ContainerSasPermissions(read=True, write=True, delete=True, list=True),
-            expiry=datetime.utcnow() + timedelta(hours=1)
+            expiry=datetime.now(timezone.utc) + timedelta(hours=1)
         )
         
         # Return the container URL (not including container name in path, it's implicit)

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import TypedDict
 
 import pandas as pd
 from openpyxl import Workbook
@@ -37,6 +38,52 @@ class Spreadsheet:
             raise ValueError(f"Unsupported file format: {path}")
         
         return cls(dataframe=df, acc_col=acc_col, mrn_col=mrn_col, date_col=date_col)
+
+
+class RunDirs(TypedDict):
+    log_dir: str
+    ctp_log_path: str
+    run_log_path: str
+    appdata_dir: str
+
+
+class HeaderExtractResult(TypedDict):
+    num_files_processed: int
+    num_studies: int
+
+
+class ImageDeidLocalResult(TypedDict):
+    num_images_saved: int
+    num_images_quarantined: int
+
+
+class PacsQueryResult(TypedDict):
+    num_studies_found: int
+    num_images_saved: int
+    num_images_quarantined: int
+    failed_query_indices: list[int]
+
+
+class DeidExportResult(TypedDict):
+    num_studies_found: int
+    num_images_exported: int
+    num_images_quarantined: int
+    failed_query_indices: list[int]
+
+
+class TextDeidResult(TypedDict):
+    num_rows_processed: int
+    output_file: str
+
+
+class SingleClickResult(TypedDict):
+    num_studies_found: int
+    num_images_exported: int
+    num_images_quarantined: int
+    failed_query_indices: list[int]
+    num_rows_processed: int
+    output_file: str
+    export_performed: bool
 
 
 def _build_mrn_date_query_and_filter(mrn, study_date, date_window_days):
@@ -421,7 +468,7 @@ def get_studies_from_study_pacs_map(study_pacs_map, application_aet, output_dir)
     return successful_gets, failed_query_indices, failure_details
 
 
-def setup_run_directories():
+def setup_run_directories() -> RunDirs:
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     
     icore_base = os.path.expanduser("~/Documents/iCore")

--- a/utils.py
+++ b/utils.py
@@ -23,9 +23,9 @@ class PacsConfiguration:
 @dataclass
 class Spreadsheet:
     dataframe: pd.DataFrame
-    acc_col: str = None
-    mrn_col: str = None
-    date_col: str = None
+    acc_col: str | None = None
+    mrn_col: str | None = None
+    date_col: str | None = None
     
     @classmethod
     def from_file(cls, path, acc_col=None, mrn_col=None, date_col=None):

--- a/utils.py
+++ b/utils.py
@@ -92,7 +92,7 @@ def generate_queries_and_filter(spreadsheet, date_window_days=0, use_fallback_qu
             query_params_list.append(query_params)
             filter_conditions.append(filter_condition)
         else:
-            raise ValueError(f"Row must have either acc_col or both mrn_col and date_col with valid values")
+            raise ValueError("Row must have either acc_col or both mrn_col and date_col with valid values")
 
     generated_filter = " + ".join(filter_conditions) if filter_conditions else None
 

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-types"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-psycopg2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/9a/5c652bbc8694489782c415d7d6fa0782219e401aba25f4d1df2b95c3a34c/django_types-0.23.0.tar.gz", hash = "sha256:f97fb746166fb15a5f40e470a1fd7a58226349aac9e0a9cb8ae81deb14d94fd0", size = 208369, upload-time = "2026-02-04T00:36:23.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/de/471afcd92022642544f7866dd5620bc85f04e4312d5e29d7f2960f31f010/django_types-0.23.0-py3-none-any.whl", hash = "sha256:0727b13ae810c4b1f14eeac9872834ac928c99dc76584ea7c23afc4461e049dd", size = 379397, upload-time = "2026-02-04T00:36:21.783Z" },
+]
+
+[[package]]
 name = "dotenv"
 version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
@@ -399,6 +411,12 @@ dependencies = [
     { name = "zipp" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "django-types" },
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-storage-blob", specifier = ">=12.28.0" },
@@ -438,6 +456,12 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2025.3" },
     { name = "tzlocal", specifier = ">=5.3.1" },
     { name = "zipp", specifier = ">=3.23.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "django-types", specifier = ">=0.23.0" },
+    { name = "ty", specifier = ">=0.0.25" },
 ]
 
 [[package]]
@@ -1222,6 +1246,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/bf/3c3147c7237277b0e8a911ff89de7183408be96b31fb42b38edb666d287f/ty-0.0.25.tar.gz", hash = "sha256:8ae3891be17dfb6acab51a2df3a8f8f6c551eb60ea674c10946dc92aae8d4401", size = 5375500, upload-time = "2026-03-24T22:32:34.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a4/6c289cbd1474285223124a4ffb55c078dbe9ae1d925d0b6a948643c7f115/ty-0.0.25-py3-none-linux_armv6l.whl", hash = "sha256:26d6d5aede5d54fb055779460f896d9c1473c6fb996716bd11cb90f027d8fee7", size = 10452747, upload-time = "2026-03-24T22:32:32.662Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/74cb9de356b9ceb3f281ab048f8c4ac2207122161b0ac0066886ce129abe/ty-0.0.25-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aedcfbc7b6b96dbc55b0da78fa02bd049373ff3d8a827f613dadd8bd17d10758", size = 10271349, upload-time = "2026-03-24T22:32:13.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/93/ffc5a20cc9e14fa9b32b0c54884864bede30d144ce2ae013805bce0c86d0/ty-0.0.25-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0a8fb3c1e28f73618941811e2568dca195178a1a6314651d4ee97086a4497253", size = 9730308, upload-time = "2026-03-24T22:32:19.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/78/52e05ef32a5f172fce70633a4e19d8e04364271a4322ae12382c7344b0de/ty-0.0.25-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814870b7f347b5d0276304cddb98a0958f08de183bf159abc920ebe321247ad4", size = 10247664, upload-time = "2026-03-24T22:32:08.669Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/64/0d0a47ed0aa1d634c666c2cc15d3b0af4b95d0fd3dbb796032bd493f3433/ty-0.0.25-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:781150e23825dc110cd5e1f50ca3d61664f7a5db5b4a55d5dbf7d3b1e246b917", size = 10261961, upload-time = "2026-03-24T22:32:43.935Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ba/4666b96f0499465efb97c244554107c541d74a1add393e62276b3de9b54f/ty-0.0.25-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc81ff2a0143911321251dc81d1c259fa5cdc56d043019a733c845d55409e2a", size = 10746076, upload-time = "2026-03-24T22:32:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ed/aa958ccbcd85cc206600e48fbf0a1c27aef54b4b90112d9a73f69ed0c739/ty-0.0.25-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f03c5c5b5c10355ea030cbe3cd93b2e759b9492c66688288ea03a68086069f2e", size = 11287331, upload-time = "2026-03-24T22:32:21.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e4/f4a004e1952e6042f5bfeeb7d09cffb379270ef009d9f8568471863e86e6/ty-0.0.25-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fc1ef49cd6262eb9223ccf6e258ac899aaa53e7dc2151ba65a2c9fa248dfa75", size = 11028804, upload-time = "2026-03-24T22:32:39.088Z" },
+    { url = "https://files.pythonhosted.org/packages/56/32/5c15bb8ea20ed54d43c734f253a2a5da95d41474caecf4ef3682df9f68f5/ty-0.0.25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ad98da1393161096235a387cc36abecd31861060c68416761eccdb7c1bc326b", size = 10845246, upload-time = "2026-03-24T22:32:41.33Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fe/4ddd83e810c8682fcfada0d1c9d38936a34a024d32d7736075c1e53a038e/ty-0.0.25-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2d4336aa5381eb4eab107c3dec75fe22943a648ef6646f5a8431ef1c8cdabb66", size = 10233515, upload-time = "2026-03-24T22:32:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/db/9fe54f6fb952e5b218f2e661e64ed656512edf2046cfbb9c159558e255db/ty-0.0.25-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e10ed39564227de2b7bd89398250b65daaedbef15a25cef8eee70078f5d9e0b2", size = 10275289, upload-time = "2026-03-24T22:32:28.21Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/090d7b33791b42bc7ec29463ac6a634738e16b289e027608ebe542682773/ty-0.0.25-py3-none-musllinux_1_2_i686.whl", hash = "sha256:aca04e9ed9b61c706064a1c0b71a247c3f92f373d0222103f3bc54b649421796", size = 10461195, upload-time = "2026-03-24T22:32:24.252Z" },
+    { url = "https://files.pythonhosted.org/packages/42/31/5bf12bce01b80b72a7a4e627380779b41510e730f6000862a1d078e423f7/ty-0.0.25-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:18a5443e4ef339c1bd8c57fc13112c22080617ea582bfc22b497d82d65361325", size = 10931471, upload-time = "2026-03-24T22:32:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/ab60c11f8a6dd2a0ae96daac83458ef2e9be1ae70481d1ad9c59d3eaf20f/ty-0.0.25-py3-none-win32.whl", hash = "sha256:a685b9a611b69195b5a557e05dbb7ebcd12815f6c32fb27fdf15edeb1fa33d8f", size = 9835974, upload-time = "2026-03-24T22:32:36.86Z" },
+    { url = "https://files.pythonhosted.org/packages/41/55/625acc2ef34646268bc2baa8fdd6e22fb47cd5965e2acd3be92c687fb6b0/ty-0.0.25-py3-none-win_amd64.whl", hash = "sha256:0d4d37a1f1ab7f2669c941c38c65144ff223eb51ececd7ccfc0d623afbc0f729", size = 10815449, upload-time = "2026-03-24T22:32:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/0147bfb543df97740b45b222c54ff79ef20fa57f14b9d2c1dab3cd7d3faa/ty-0.0.25-py3-none-win_arm64.whl", hash = "sha256:d80b8cd965cbacbfd887ac2d985f5b6da09b7aa3569371e2894e0b30b26b89cd", size = 10225494, upload-time = "2026-03-24T22:32:30.611Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1246,6 +1294,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
+]
+
+[[package]]
+name = "types-psycopg2"
+version = "2.9.21.20260223"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/1f/4daff0ce5e8e191844e65aaa793ed1b9cb40027dc2700906ecf2b6bcc0ed/types_psycopg2-2.9.21.20260223.tar.gz", hash = "sha256:78ed70de2e56bc6b5c26c8c1da8e9af54e49fdc3c94d1504609f3519e2b84f02", size = 27090, upload-time = "2026-02-23T04:11:18.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/e7/c566df58410bc0728348b514e718f0b38fa0d248b5c10599a11494ba25d2/types_psycopg2-2.9.21.20260223-py3-none-any.whl", hash = "sha256:c6228ade72d813b0624f4c03feeb89471950ac27cd0506b5debed6f053086bc8", size = 24919, upload-time = "2026-02-23T04:11:17.214Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -414,6 +414,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "django-types" },
+    { name = "ruff" },
     { name = "ty" },
 ]
 
@@ -461,6 +462,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "django-types", specifier = ">=0.23.0" },
+    { name = "ruff", specifier = ">=0.15.7" },
     { name = "ty", specifier = ">=0.0.25" },
 ]
 
@@ -1057,6 +1059,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
     { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
     { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -359,6 +359,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -414,6 +423,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "django-types" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -462,6 +472,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "django-types", specifier = ">=0.23.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.7" },
     { name = "ty", specifier = ">=0.0.25" },
 ]
@@ -911,6 +922,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR improves the development infrastructure around iCore by implementing static linting (via the `ruff` tool), static type checking via `ty`, and improving test speed by parallelizing test runs with `pytest-xdist` and consolidating slow test fixtures into module-level scopes.